### PR TITLE
Apply renderer default settings & force light intensity

### DIFF
--- a/omnigibson/macros.py
+++ b/omnigibson/macros.py
@@ -68,6 +68,9 @@ gm.USE_ENCRYPTED_ASSETS = True
 # (Demo-purpose) Whether to activate Assistive Grasping mode for Cloth (it's handled differently from RigidBody)
 gm.AG_CLOTH = False
 
+# Forced light intensity for all USD-loaded objects
+gm.FORCE_USD_LIGHT_INTENSITY = 500000
+
 
 # Create helper function for generating sub-dictionaries
 def create_module_macros(module_path):

--- a/omnigibson/macros.py
+++ b/omnigibson/macros.py
@@ -68,8 +68,11 @@ gm.USE_ENCRYPTED_ASSETS = True
 # (Demo-purpose) Whether to activate Assistive Grasping mode for Cloth (it's handled differently from RigidBody)
 gm.AG_CLOTH = False
 
-# Forced light intensity for all USD-loaded objects
-gm.FORCE_USD_LIGHT_INTENSITY = 500000
+# Forced light intensity for all DatasetObjects. None if the USD-provided intensities should be respected.
+gm.FORCE_LIGHT_INTENSITY = 500000
+
+# Forced roughness for all DatasetObjects. None if the USD-provided roughness maps should be respected.
+gm.FORCE_ROUGHNESS = 0.7
 
 
 # Create helper function for generating sub-dictionaries

--- a/omnigibson/objects/dataset_object.py
+++ b/omnigibson/objects/dataset_object.py
@@ -239,7 +239,6 @@ class DatasetObject(USDObject):
                 joint.friction = friction
 
     def _load(self, simulator=None):
-        prim = None
         if gm.USE_ENCRYPTED_ASSETS:
             # Create a temporary file to store the decrytped asset, load it, and then delete it.
             with tempfile.NamedTemporaryFile(suffix=".usd") as fp:

--- a/omnigibson/objects/dataset_object.py
+++ b/omnigibson/objects/dataset_object.py
@@ -221,16 +221,10 @@ class DatasetObject(USDObject):
             recursive_light_update(self._prim)
 
         # Apply any forced roughness updates
-        if gm.FORCE_ROUGHNESS is not None:
-            def recursive_roughness_update(child_prim):
-                if child_prim.GetPrimTypeInfo().GetTypeName() == "Shader":
-                    child_prim.GetAttribute("inputs:reflection_roughness_texture_influence").Set(0.0)
-                    child_prim.GetAttribute("inputs:reflection_roughness_constant").Set(gm.FORCE_ROUGHNESS)
-
-                for child_child_prim in child_prim.GetChildren():
-                    recursive_roughness_update(child_child_prim)
-
-            recursive_roughness_update(self._prim)
+        for material in self.materials:
+            shader = material.GetChild("Shader")
+            shader.GetAttribute("inputs:reflection_roughness_texture_influence").Set(0.0)
+            shader.GetAttribute("inputs:reflection_roughness_constant").Set(gm.FORCE_ROUGHNESS)
 
         # Set the joint frictions based on category
         friction = SPECIAL_JOINT_FRICTIONS.get(self.category, DEFAULT_JOINT_FRICTION)

--- a/omnigibson/objects/dataset_object.py
+++ b/omnigibson/objects/dataset_object.py
@@ -210,7 +210,7 @@ class DatasetObject(USDObject):
         if gm.FORCE_LIGHT_INTENSITY is not None:
             def recursive_light_update(child_prim):
                 if "Light" in child_prim.GetPrimTypeInfo().GetTypeName():
-                    child_prim.GetAttribute("intensity").Set(gm.FORCE_USD_LIGHT_INTENSITY)
+                    child_prim.GetAttribute("intensity").Set(gm.FORCE_LIGHT_INTENSITY)
 
                 for child_child_prim in child_prim.GetChildren():
                     recursive_light_update(child_child_prim)
@@ -222,7 +222,7 @@ class DatasetObject(USDObject):
             def recursive_roughness_update(child_prim):
                 if child_prim.GetPrimTypeInfo().GetTypeName() == "Shader":
                     child_prim.GetAttribute("inputs:reflection_roughness_texture_influence").Set(0.0)
-                    child_prim.GetAttribute("inputs:reflection_roughness_constant").Set(gm.FORCE_USD_ROUGHNESS)
+                    child_prim.GetAttribute("inputs:reflection_roughness_constant").Set(gm.FORCE_ROUGHNESS)
 
                 for child_child_prim in child_prim.GetChildren():
                     recursive_roughness_update(child_child_prim)

--- a/omnigibson/objects/dataset_object.py
+++ b/omnigibson/objects/dataset_object.py
@@ -222,9 +222,8 @@ class DatasetObject(USDObject):
 
         # Apply any forced roughness updates
         for material in self.materials:
-            shader = material.GetChild("Shader")
-            shader.GetAttribute("inputs:reflection_roughness_texture_influence").Set(0.0)
-            shader.GetAttribute("inputs:reflection_roughness_constant").Set(gm.FORCE_ROUGHNESS)
+            material.reflection_roughness_texture_influence = 0.0
+            material.reflection_roughness_constant = gm.FORCE_ROUGHNESS
 
         # Set the joint frictions based on category
         friction = SPECIAL_JOINT_FRICTIONS.get(self.category, DEFAULT_JOINT_FRICTION)

--- a/omnigibson/objects/dataset_object.py
+++ b/omnigibson/objects/dataset_object.py
@@ -225,7 +225,7 @@ class DatasetObject(USDObject):
                     child_prim.GetAttribute("inputs:reflection_roughness_constant").Set(gm.FORCE_USD_ROUGHNESS)
 
                 for child_child_prim in child_prim.GetChildren():
-                    recursive_light_update(child_child_prim)
+                    recursive_roughness_update(child_child_prim)
 
             recursive_roughness_update(self.root_prim)
 

--- a/omnigibson/objects/dataset_object.py
+++ b/omnigibson/objects/dataset_object.py
@@ -206,6 +206,9 @@ class DatasetObject(USDObject):
         return rotated_quat
 
     def _initialize(self):
+        # Run super method first
+        super()._initialize()
+
         # Apply any forced light intensity updates.
         if gm.FORCE_LIGHT_INTENSITY is not None:
             def recursive_light_update(child_prim):
@@ -215,7 +218,7 @@ class DatasetObject(USDObject):
                 for child_child_prim in child_prim.GetChildren():
                     recursive_light_update(child_child_prim)
 
-            recursive_light_update(self.root_prim)
+            recursive_light_update(self._prim)
 
         # Apply any forced roughness updates
         if gm.FORCE_ROUGHNESS is not None:
@@ -227,10 +230,7 @@ class DatasetObject(USDObject):
                 for child_child_prim in child_prim.GetChildren():
                     recursive_roughness_update(child_child_prim)
 
-            recursive_roughness_update(self.root_prim)
-
-        # Run super method first
-        super()._initialize()
+            recursive_roughness_update(self._prim)
 
         # Set the joint frictions based on category
         friction = SPECIAL_JOINT_FRICTIONS.get(self.category, DEFAULT_JOINT_FRICTION)

--- a/omnigibson/simulator.py
+++ b/omnigibson/simulator.py
@@ -209,6 +209,14 @@ class Simulator(SimulationContext, Serializable):
         self._physics_context.set_gpu_total_aggregate_pairs_capacity(gm.GPU_AGGR_PAIRS_CAPACITY)
         self._physics_context.set_gpu_max_particle_contacts(gm.GPU_MAX_PARTICLE_CONTACTS)
 
+    def _set_renderer_settings(self):
+        # TODO: For now we are setting these to some reasonable high-performance values but these can be made configurable.
+        carb.settings.get_settings().set_bool("/rtx/reflections/enabled", False)  # Can be true with a 10fps penalty
+        carb.settings.get_settings().set_bool("/rtx/indirectDiffuse/enabled", False)  # Can be True with a 5fps penalty
+        carb.settings.get_settings().set_bool("/rtx/directLighting/sampledLighting/enabled", True)
+        carb.settings.get_settings().set_int("/rtx/raytracing/showLights", 1)
+        carb.settings.get_settings().set_float("/rtx/sceneDb/ambientLightIntensity", 0.1)
+
     @property
     def viewer_visibility(self):
         """
@@ -899,6 +907,7 @@ class Simulator(SimulationContext, Serializable):
             stage_units_in_meters=self._initial_stage_units_in_meters,
         )
         self._set_physics_engine_settings()
+        self._set_renderer_settings()
         self._setup_default_callback_fns()
         self._stage_open_callback = (
             omni.usd.get_context().get_stage_event_stream().create_subscription_to_pop(self._stage_open_callback_fn)

--- a/omnigibson/simulator.py
+++ b/omnigibson/simulator.py
@@ -211,11 +211,12 @@ class Simulator(SimulationContext, Serializable):
 
     def _set_renderer_settings(self):
         # TODO: For now we are setting these to some reasonable high-performance values but these can be made configurable.
-        carb.settings.get_settings().set_bool("/rtx/reflections/enabled", False)  # Can be true with a 10fps penalty
-        carb.settings.get_settings().set_bool("/rtx/indirectDiffuse/enabled", False)  # Can be True with a 5fps penalty
+        carb.settings.get_settings().set_bool("/rtx/reflections/enabled", False)  # Can be True with a 10fps penalty
+        carb.settings.get_settings().set_bool("/rtx/indirectDiffuse/enabled", True)  # Can be False with a 5fps gain
         carb.settings.get_settings().set_bool("/rtx/directLighting/sampledLighting/enabled", True)
         carb.settings.get_settings().set_int("/rtx/raytracing/showLights", 1)
         carb.settings.get_settings().set_float("/rtx/sceneDb/ambientLightIntensity", 0.1)
+        carb.settings.get_settings().set_int("/rtx/domeLight/upperLowerStrategy", 3)  # "Limited image-based"
 
     @property
     def viewer_visibility(self):

--- a/omnigibson/utils/usd_utils.py
+++ b/omnigibson/utils/usd_utils.py
@@ -637,17 +637,6 @@ def add_asset_to_stage(asset_path, prim_path):
     # Make sure prim was loaded correctly
     assert prim, f"Failed to load {asset_type.upper()} object from path: {asset_path}"
 
-    # Apply any forced light intensity updates.
-    if gm.FORCE_USD_LIGHT_INTENSITY:
-        def recursive_light_update(child_prim):
-            if "Light" in child_prim.GetPrimTypeInfo().GetTypeName():
-                child_prim.GetAttribute("intensity").Set(gm.FORCE_USD_LIGHT_INTENSITY)
-
-            for child_child_prim in child_prim.GetChildren():
-                recursive_light_update(child_child_prim)
-
-        recursive_light_update(prim)
-
     return prim
 
 

--- a/omnigibson/utils/usd_utils.py
+++ b/omnigibson/utils/usd_utils.py
@@ -637,6 +637,17 @@ def add_asset_to_stage(asset_path, prim_path):
     # Make sure prim was loaded correctly
     assert prim, f"Failed to load {asset_type.upper()} object from path: {asset_path}"
 
+    # Apply any forced light intensity updates.
+    if gm.FORCE_USD_LIGHT_INTENSITY:
+        def recursive_light_update(child_prim):
+            if "Light" in child_prim.GetPrimTypeInfo().GetTypeName():
+                child_prim.GetAttribute("intensity").Set(gm.FORCE_USD_LIGHT_INTENSITY)
+
+            for child_child_prim in child_prim.GetChildren():
+                recursive_light_update(child_child_prim)
+
+        recursive_light_update(prim)
+
     return prim
 
 


### PR DESCRIPTION
To get the default rendering behavior to a reasonable value, we:

- Force all usd-based lights to the same, reasonable intensity (this will need to be fixed in the assets later with a principled solution)
- Change direct lighting to sampling mode (this is important for two reasons: it adds performance in many-light settings, and it allows reflections to not be buggy)
- Reduce ambient lighting such that most of the pixel value comes from actual lights
- Make lights visible (otherwise only their reflections are visible which is weird)
- For now, disable both indirectDiffuse and reflections.
  - indirectDiffuse can be enabled with a 5fps penalty to get corners etc. better lit. Maybe this should be enabled in the long-run default setting.
  - reflections can be enabled with a 10fps penalty

I also left a todo to later allow the user to configure the rendering to one of a few presets that we can provide (otherwise the renderer setting rabbit hole is rather deep).

cc @mjlbach , @ChengshuLi 