### PR TITLE
Make the decrypted context manager work on Windows

### DIFF
--- a/omnigibson/utils/asset_utils.py
+++ b/omnigibson/utils/asset_utils.py
@@ -490,10 +490,9 @@ def encrypt_file(original_filename, encrypted_filename=None, encrypted_file=None
 @contextlib.contextmanager
 def decrypted(encrypted_filename):
     fpath = Path(encrypted_filename)
-    decrypted_filename = f"{fpath.stem}.tmp{fpath.suffix}"
+    decrypted_filename = os.path.join(og.tempdir, f"{fpath.stem}.tmp{fpath.suffix}")
     decrypt_file(encrypted_filename=encrypted_filename, decrypted_filename=decrypted_filename)
     yield decrypted_filename
-    os.remove(decrypted_filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently the USD library leaks file handles, meaning any files opened with either Omni or Usd.Stage cannot be deleted during the lifetime of the application. This seeks to avoid that issue by delegating it to the og tempdir (which may or may not be immediately removed, however, the OS should eventually remove the entire directory)