### PR TITLE
Update OG docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 * 🤖 Mobile Manipulator Robots with Modular ⚙️ Controllers
 * 🌎 OpenAI Gym Interface
 
-Check out [**`OmniGibson`**'s documentation](https://stanfordvl.github.io/OmniGibson/getting_started/installation.html) to get started!
+Check out [**`OmniGibson`**'s documentation](https://behavior.stanford.edu/omnigibson/getting_started/installation.html) to get started!
 
 ### Citation
 If you use **`OmniGibson`** or its assets and models, please cite:


### PR DESCRIPTION
We will need to cherrypick this on main to update the link on the homepage. Also later we will need to merge main into og-develop first before we can push og-develop as main.