### PR TITLE
linux setup fix

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,7 +28,8 @@ echo -e "\nUsing [4m$conda_name[0m as the conda environment name\n"
 
 # Get Python version from Isaac Sim
 ISAAC_PYTHON_VERSION=$(${ISAAC_SIM_PATH}/python.sh -c "import platform; print(platform.python_version())")
-echo Using Python version [4m$ISAAC_PYTHON_VERSION[0m matching your current Isaac Sim version
+ISAAC_PYTHON_VERSION="${ISAAC_PYTHON_VERSION##*$'\n'}" # get rid of conda activation warnings
+echo Using Python version [4m$ISAAC_PYTHON_VERSION[0m matching your current Isaac Sim version
 
 # Create a conda environment with the appropriate python version
 source $(conda info --base)/etc/profile.d/conda.sh


### PR DESCRIPTION
Fix the following error when running setup script in another conda environment (e.g. base):

`Using Python version Warning: running in conda env, please deactivate before executing this script If conda is desired please source setup_conda_env.sh in your python 3.7 conda env and run python normally 3.7.13 matching your current Isaac Sim version `

`CondaValueError: invalid package specification: python=Warning:`