### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build-push-containers.yml
+++ b/.github/workflows/build-push-containers.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   docker:
-    runs-on: [self-hosted, linux, gpu]
+    runs-on: ubuntu-latest
     steps:
       -
         name: Checkout

--- a/.github/workflows/build-push-containers.yml
+++ b/.github/workflows/build-push-containers.yml
@@ -13,25 +13,31 @@ jobs:
     runs-on: [self-hosted, linux, gpu]
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to NVCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: nvcr.io
           username: ${{ secrets.NVCR_USERNAME }}
           password: ${{ secrets.NVCR_PASSWORD }}   
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       -
         name: Metadata for dev Image
         id: meta-dev
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             stanfordvl/omnigibson-dev
@@ -41,7 +47,7 @@ jobs:
       -
         name: Metadata for prod Image
         id: meta-prod
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             stanfordvl/omnigibson
@@ -50,7 +56,7 @@ jobs:
             type=semver,pattern={{version}}
       -
         name: Build and push dev image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ steps.meta-dev.outputs.tags }}
@@ -60,7 +66,7 @@ jobs:
           cache-to: type=gha,mode=max
       -
         name: Build and push prod image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ steps.meta-prod.outputs.tags }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,26 +8,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: [self-hosted, linux, gpu]
-    container:
-      image: stanfordvl/omnigibson-dev:latest
-      options: --gpus=all --privileged --user=root
-      env:
-        DISPLAY: ""
-        OMNIGIBSON_HEADLESS: 1
-      volumes:
-        - /scr/omni-data/datasets:/data
-        - /usr/share/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json
-        - /usr/share/vulkan/icd.d/nvidia_layers.json:/etc/vulkan/implicit_layer.d/nvidia_layers.json
-        - /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json
-        - /scr/omni-data/isaac-sim/cache/ov:/root/.cache/ov:rw
-        - /scr/omni-data/isaac-sim/cache/pip:/root/.cache/pip:rw
-        - /scr/omni-data/isaac-sim/cache/glcache:/root/.cache/nvidia/GLCache:rw
-        - /scr/omni-data/isaac-sim/cache/computecache:/root/.nv/ComputeCache:rw
-        - /scr/omni-data/isaac-sim/logs:/root/.nvidia-omniverse/logs:rw
-        - /scr/omni-data/isaac-sim/config:/root/.nvidia-omniverse/config:rw
-        - /scr/omni-data/isaac-sim/data:/root/.local/share/ov/data:rw
-        - /scr/omni-data/isaac-sim/documents:/root/Documents:rw
+    runs-on: [self-hosted, linux, gpu, dataset-enabled]
 
     defaults:
       run:

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/isaac-sim:2022.2.0
+FROM nvcr.io/nvidia/isaac-sim:2023.1.0
 
 # Set up all the prerequisites.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -19,7 +19,7 @@ ENV OMNIGIBSON_KEY_PATH /data/omnigibson.key
 # Install Mamba (light conda alternative)
 RUN curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C / bin/micromamba
 ENV MAMBA_ROOT_PREFIX /micromamba
-RUN micromamba create -n omnigibson -c conda-forge python=3.7
+RUN micromamba create -n omnigibson -c conda-forge python=3.10
 RUN micromamba shell init --shell=bash --prefix=/micromamba
 
 # Make sure isaac gets properly sourced every time omnigibson gets called
@@ -45,8 +45,8 @@ RUN cd /ompl/build/Release && \
     micromamba run -n omnigibson cmake ../.. \
       -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" \
       -DBOOST_ROOT="$CONDA_PREFIX" \
-      -DPYTHON_EXEC=/micromamba/envs/omnigibson/bin/python3.7 \
-      -DPYTHONPATH=/micromamba/envs/omnigibson/lib/python3.7/site-packages && \
+      -DPYTHON_EXEC=/micromamba/envs/omnigibson/bin/python3.10 \
+      -DPYTHONPATH=/micromamba/envs/omnigibson/lib/python3.10/site-packages && \
     micromamba run -n omnigibson make -j 4 update_bindings && \
     micromamba run -n omnigibson make -j 4 && \
     cd py-bindings && \

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -26,55 +26,6 @@ do
     esac
 done
 
-ICD_PATH_1="/usr/share/vulkan/icd.d/nvidia_icd.json"
-ICD_PATH_2="/etc/vulkan/icd.d/nvidia_icd.json"
-LAYERS_PATH_1="/usr/share/vulkan/icd.d/nvidia_layers.json"
-LAYERS_PATH_2="/usr/share/vulkan/implicit_layer.d/nvidia_layers.json"
-LAYERS_PATH_3="/etc/vulkan/implicit_layer.d/nvidia_layers.json"
-EGL_VENDOR_PATH="/usr/share/glvnd/egl_vendor.d/10_nvidia.json"
-
-# Find the ICD file
-if [ -e "$ICD_PATH_1" ]; then
-    ICD_PATH=$ICD_PATH_1
-elif [ -e "$ICD_PATH_2" ]; then
-    ICD_PATH=$ICD_PATH_2
-else
-    echo "Missing nvidia_icd.json file.";
-    echo "Typical paths:";
-    echo "- /usr/share/vulkan/icd.d/nvidia_icd.json or";
-    echo "- /etc/vulkan/icd.d/nvidia_icd.json";
-    echo "You can google nvidia_icd.json for your distro to find the correct path.";
-    echo "Consider updating your driver to 525 if you cannot find the file.";
-    echo "To continue update the ICD_PATH_1 at the top of the run_docker.sh file and retry";
-    exit;
-fi
-
-# Find the layers file
-if [ -e "$LAYERS_PATH_1" ]; then
-    LAYERS_PATH=$LAYERS_PATH_1
-elif [ -e "$LAYERS_PATH_2" ]; then
-    LAYERS_PATH=$LAYERS_PATH_2
-elif [ -e "$LAYERS_PATH_3" ]; then
-    LAYERS_PATH=$LAYERS_PATH_3
-else
-    echo "Missing nvidia_layers.json file."
-    echo "Typical paths:";
-    echo "- /usr/share/vulkan/icd.d/nvidia_layers.json";
-    echo "- /usr/share/vulkan/implicit_layer.d/nvidia_layers.json";
-    echo "- /etc/vulkan/implicit_layer.d/nvidia_layers.json";
-    echo "You can google nvidia_layers.json for your distro to find the correct path.";
-    echo "Consider updating your driver to 525 if you cannot find the file.";
-    echo "To continue update the LAYERS_PATH_1 at the top of the run_docker.sh file and retry";
-    exit;
-fi 
-
-if [ ! -e "$EGL_VENDOR_PATH" ]; then
-    echo "Missing ${EGL_VENDOR_PATH} file."
-    echo "(default path: /usr/share/vulkan/icd.d/nvidia_icd.json)";
-    echo "To continue update the EGL_VENDOR_PATH at the top of the run_docker.sh file and retry";
-    exit;
-fi 
-
 # Move directories from their legacy paths.
 if [ -e "${DATA_PATH}/og_dataset" ]; then
     mv "${DATA_PATH}/og_dataset" "${DATA_PATH}/datasets/og_dataset"
@@ -117,9 +68,6 @@ docker run \
     -e DISPLAY=${DOCKER_DISPLAY} \
     -e OMNIGIBSON_HEADLESS=${OMNIGIBSON_HEADLESS} \
     -v $DATA_PATH/datasets:/data \
-    -v ${ICD_PATH}:/etc/vulkan/icd.d/nvidia_icd.json \
-    -v ${LAYERS_PATH}:/etc/vulkan/implicit_layer.d/nvidia_layers.json \
-    -v ${EGL_VENDOR_PATH}:/usr/share/glvnd/egl_vendor.d/10_nvidia.json \
     -v $DATA_PATH/isaac-sim/cache/kit:/isaac-sim/kit/cache/Kit:rw \
     -v $DATA_PATH/isaac-sim/cache/ov:/root/.cache/ov:rw \
     -v $DATA_PATH/isaac-sim/cache/pip:/root/.cache/pip:rw \


### PR DESCRIPTION
This updates the test workflow to run without a container in the new slurm runner setup, the docker workflow to run on github-hosted actions runners (since we can't build docker images in our containerized runners), and switches our images to use Isaac Sim 2023.1.0