### PR TITLE
Add slicer delay to fix slicing demo

### DIFF
--- a/omnigibson/object_states/__init__.py
+++ b/omnigibson/object_states/__init__.py
@@ -23,6 +23,7 @@ from omnigibson.object_states.particle_source_or_sink import ParticleSource, Par
 from omnigibson.object_states.pose import Pose
 from omnigibson.object_states.robot_related_states import IsGrasping
 from omnigibson.object_states.saturated import Saturated
+from omnigibson.object_states.slicer_active import SlicerActive
 from omnigibson.object_states.temperature import Temperature
 from omnigibson.object_states.toggle import ToggledOn
 from omnigibson.object_states.touching import Touching

--- a/omnigibson/object_states/factory.py
+++ b/omnigibson/object_states/factory.py
@@ -23,7 +23,7 @@ _ABILITY_TO_STATE_MAPPING = {
     "flammable": [OnFire],
     "saturable": [Saturated],
     "sliceable": [],
-    "slicer": [],
+    "slicer": [SlicerActive],
     "toggleable": [ToggledOn],
     "cloth": [Folded, Unfolded, Overlaid, Draped],
     "fillable": [Filled, Contains],

--- a/omnigibson/object_states/slicer_active.py
+++ b/omnigibson/object_states/slicer_active.py
@@ -68,7 +68,6 @@ class SlicerActive(AbsoluteObjectState, UpdateStateMixin):
         # Record if we were touching anything previously
         self._previously_touching_sliceable = currently_touching_sliceable
 
-
     @property
     def state_size(self):
         return 2

--- a/omnigibson/object_states/slicer_active.py
+++ b/omnigibson/object_states/slicer_active.py
@@ -1,0 +1,74 @@
+import numpy as np
+from omnigibson.macros import create_module_macros
+from omnigibson.object_states.object_state_base import AbsoluteObjectState
+from omnigibson.object_states.aabb import AABB
+from omnigibson.object_states.contact_bodies import ContactBodies
+from omnigibson.object_states.update_state_mixin import UpdateStateMixin
+import omnigibson as og
+
+
+# Create settings for this module
+m = create_module_macros(module_path=__file__)
+
+class SlicerActive(AbsoluteObjectState, UpdateStateMixin):
+    @classmethod
+    def get_dependencies(cls):
+        deps = super().get_dependencies()
+        deps.add(AABB)
+        deps.add(ContactBodies)
+        return deps
+
+    def __init__(self, obj):
+        super(SlicerActive, self).__init__(obj)
+
+        self._previously_touching_sliceable = False
+        self.value = True
+
+    def _get_value(self):
+        return self.value
+
+    def _set_value(self, new_value):
+        self.value = new_value
+        return True
+    
+    def _currently_touching_sliceable(self):
+        # TODO: Implement something
+        # Get the contact prim list from ContactBodies, then get objects from prim paths, then check if they are sliceable
+        # Use self.obj.get_state(ContactBodies) to return a set of objects that are currently touching self.obj
+        return False
+
+    def _update(self):
+        # If we were slicing in the past step, deactivate now.
+        if self._previously_touching_sliceable:
+            self.set_value(False)
+
+        # Are we currently touching any sliceables?
+        currently_touching_sliceable = self._currently_touching_sliceable()
+
+        # If our value is False, we need to consider reverting back.
+        if not self.value:
+            # If we are not touching any sliceable objects, we can revert to True.
+            if currently_touching_sliceable:
+                self.set_value(True)
+
+        # Record if we were touching anything previously
+        self._previously_touching_sliceable = currently_touching_sliceable
+
+
+    @property
+    def state_size(self):
+        return 2
+
+    # For this state, we simply store its value.
+    def _dump_state(self):
+        return dict(value=self.value, previously_touching_sliceable=self._previously_touching_sliceable)
+
+    def _load_state(self, state):
+        self.value = state["value"]
+        self._previously_touching_sliceable = state["previously_touching_sliceable"]
+
+    def _serialize(self, state):
+        return np.array([state["value"], state["previously_touching_sliceable"]], dtype=float)
+
+    def _deserialize(self, state):
+        return dict(value=state[0], previously_touching_sliceable=state[1]), 2

--- a/omnigibson/object_states/slicer_active.py
+++ b/omnigibson/object_states/slicer_active.py
@@ -32,12 +32,11 @@ class SlicerActive(AbsoluteObjectState, UpdateStateMixin):
         return True
     
     def _currently_touching_sliceable(self):
-        # TODO: Implement something
-        # Get the contact prim list from ContactBodies, then get objects from prim paths, then check if they are sliceable
-        # Use self.obj.get_state(ContactBodies) to return a set of objects that are currently touching self.obj
-        return False
+        all_touching_objects = self.obj.states[ContactBodies].get_value()
+        return any(hasattr(obj, '_abilities') and "Sliceable" in obj._abilities for obj in all_touching_objects)
 
     def _update(self):
+        breakpoint()
         # If we were slicing in the past step, deactivate now.
         if self._previously_touching_sliceable:
             self.set_value(False)

--- a/omnigibson/transition_rules.py
+++ b/omnigibson/transition_rules.py
@@ -793,7 +793,8 @@ class DicingRule(BaseTransitionRule):
     @classmethod
     def _generate_conditions(cls):
         # sliceables should be touching any slicer
-        return [TouchingAnyCondition(filter_1_name="diceable", filter_2_name="slicer")]
+        return [TouchingAnyCondition(filter_1_name="diceable", filter_2_name="slicer"),
+                StateCondition(filter_name="slicer", state=SlicerActive, val=True, op=operator.eq)]
 
     @classmethod
     def transition(cls, object_candidates):

--- a/omnigibson/transition_rules.py
+++ b/omnigibson/transition_rules.py
@@ -723,7 +723,8 @@ class SlicingRule(BaseTransitionRule):
     @classmethod
     def _generate_conditions(cls):
         # sliceables should be touching any slicer
-        return [TouchingAnyCondition(filter_1_name="sliceable", filter_2_name="slicer")]
+        return [TouchingAnyCondition(filter_1_name="sliceable", filter_2_name="slicer"),
+                StateCondition(filter_name="slicer", state=SlicerActive, val=True, op=operator.eq)]
 
     @classmethod
     def transition(cls, object_candidates):


### PR DESCRIPTION
#316 
This PR tries to fix the slicing demo where the knife slices an apple and immediately dices it. 

To fix this, we've introduced a manual delay that temporarily deactivates the slicer after it gets into contact with a sliceable. 

Currently, the delay is set to 7 frames, which is the minimum required for this demo to function correctly. However, this delay is really arbitrarily and may not work in other scenarios. For example, in our demo, the knife is moved by gravity, which is significantly faster than a robot arm manipulating the knife. 

I could really use everyone's opinion on this. Let me know what you think the best way to do this is! Thanks. 