### PR TITLE
Fix AG object not in hand after reloading

### DIFF
--- a/omnigibson/robots/manipulation_robot.py
+++ b/omnigibson/robots/manipulation_robot.py
@@ -1396,7 +1396,7 @@ class ManipulationRobot(BaseRobot):
             return state
 
         # Include AG_state
-        state["ag_obj_constraint_params"] = self._ag_obj_constraint_params
+        state["ag_obj_constraint_params"] = self._ag_obj_constraint_params.copy()
         return state
 
     def _load_state(self, state):
@@ -1417,8 +1417,7 @@ class ManipulationRobot(BaseRobot):
                 data = state["ag_obj_constraint_params"][arm]
                 obj = og.sim.scene.object_registry("prim_path", data["ag_obj_prim_path"])
                 link = obj.links[data["ag_link_prim_path"].split("/")[-1]]
-                self._ag_data[arm] = (obj, link)
-                self._establish_grasp(arm=arm, ag_data=self._ag_data[arm], contact_pos=data["contact_pos"])
+                self._establish_grasp(arm=arm, ag_data=(obj, link), contact_pos=data["contact_pos"])
 
     def _serialize(self, state):
         # Call super first

--- a/tests/test_symbolic_primitives.py
+++ b/tests/test_symbolic_primitives.py
@@ -161,151 +161,155 @@ def sponge(env):
 def knife(env):
   return next(iter(env.scene.object_registry("category", "carving_knife")))
 
-@pytest.mark.skip(reason="primitives are broken")
-def test_in_hand_state(env, robot, prim_gen, apple):
-  assert not robot.states[object_states.IsGrasping].get_value(apple)
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, apple):
-    env.step(action)
-  assert robot.states[object_states.IsGrasping].get_value(apple)
+class TestSymbolicPrimitives:
+  @pytest.mark.skip(reason="primitives are broken")
+  def test_in_hand_state(self, env, robot, prim_gen, apple):
+    assert not robot.states[object_states.IsGrasping].get_value(apple)
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, apple):
+      env.step(action)
+    assert robot.states[object_states.IsGrasping].get_value(apple)
 
-# def test_navigate():
-#    pass
+  # def test_navigate():
+  #    pass
 
-@pytest.mark.skip(reason="primitives are broken")
-def test_open(env, prim_gen, fridge):
-  assert not fridge.states[object_states.Open].get_value()
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.OPEN, fridge):
-    env.step(action)
-  assert fridge.states[object_states.Open].get_value()
+  @pytest.mark.skip(reason="primitives are broken")
+  def test_open(self, env, prim_gen, fridge):
+    assert not fridge.states[object_states.Open].get_value()
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.OPEN, fridge):
+      env.step(action)
+    assert fridge.states[object_states.Open].get_value()
 
-@pytest.mark.skip(reason="primitives are broken")
-def test_close(env, prim_gen, fridge):
-  fridge.states[object_states.Open].set_value(True)
-  assert fridge.states[object_states.Open].get_value()
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.CLOSE, fridge):
-    env.step(action)
-  assert not fridge.states[object_states.Open].get_value()
+  @pytest.mark.skip(reason="primitives are broken")
+  def test_close(self, env, prim_gen, fridge):
+    fridge.states[object_states.Open].set_value(True)
+    assert fridge.states[object_states.Open].get_value()
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.CLOSE, fridge):
+      env.step(action)
+    assert not fridge.states[object_states.Open].get_value()
 
-@pytest.mark.skip(reason="primitives are broken")
-def test_place_inside(env, prim_gen, apple, fridge):
-  assert not apple.states[object_states.Inside].get_value(fridge)
-  assert not fridge.states[object_states.Open].get_value()
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.OPEN, fridge):
-    env.step(action)
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, apple):
-    env.step(action)
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.PLACE_INSIDE, fridge):
-    env.step(action)
-  assert apple.states[object_states.Inside].get_value(fridge)
+  @pytest.mark.skip(reason="primitives are broken")
+  def test_place_inside(self, env, prim_gen, apple, fridge):
+    assert not apple.states[object_states.Inside].get_value(fridge)
+    assert not fridge.states[object_states.Open].get_value()
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.OPEN, fridge):
+      env.step(action)
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, apple):
+      env.step(action)
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.PLACE_INSIDE, fridge):
+      env.step(action)
+    assert apple.states[object_states.Inside].get_value(fridge)
 
-@pytest.mark.skip(reason="primitives are broken")
-def test_place_ontop(env, prim_gen, apple, pan):
-  assert not apple.states[object_states.OnTop].get_value(pan)
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, apple):
-    env.step(action)
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.PLACE_ON_TOP, pan):
-    env.step(action)
-  assert apple.states[object_states.OnTop].get_value(pan)
+  @pytest.mark.skip(reason="primitives are broken")
+  def test_place_ontop(self, env, prim_gen, apple, pan):
+    assert not apple.states[object_states.OnTop].get_value(pan)
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, apple):
+      env.step(action)
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.PLACE_ON_TOP, pan):
+      env.step(action)
+    assert apple.states[object_states.OnTop].get_value(pan)
 
-@pytest.mark.skip(reason="primitives are broken")
-def test_toggle_on(env, prim_gen, stove):
-  assert not stove.states[object_states.ToggledOn].get_value()
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.TOGGLE_ON, stove):
-    env.step(action)
-  assert stove.states[object_states.ToggledOn].get_value()
+  @pytest.mark.skip(reason="primitives are broken")
+  def test_toggle_on(self, env, prim_gen, stove):
+    assert not stove.states[object_states.ToggledOn].get_value()
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.TOGGLE_ON, stove):
+      env.step(action)
+    assert stove.states[object_states.ToggledOn].get_value()
 
-@pytest.mark.skip(reason="primitives are broken")
-def test_soak_under(env, prim_gen, robot, sponge, sink):
-  water_system = get_system("water", force_active=True)
-  assert not sponge.states[object_states.Saturated].get_value(water_system)
-  assert not sink.states[object_states.ToggledOn].get_value()
+  @pytest.mark.skip(reason="primitives are broken")
+  def test_soak_under(self, env, prim_gen, robot, sponge, sink):
+    water_system = get_system("water", force_active=True)
+    assert not sponge.states[object_states.Saturated].get_value(water_system)
+    assert not sink.states[object_states.ToggledOn].get_value()
 
-  # First toggle on the sink
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.TOGGLE_ON, sink):
-    env.step(action)
-  assert sink.states[object_states.ToggledOn].get_value()
+    # First toggle on the sink
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.TOGGLE_ON, sink):
+      env.step(action)
+    assert sink.states[object_states.ToggledOn].get_value()
 
-  # Then grasp the sponge
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, sponge):
-    env.step(action)
-  assert robot.states[object_states.IsGrasping].get_value(sponge)
+    # Then grasp the sponge
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, sponge):
+      env.step(action)
+    assert robot.states[object_states.IsGrasping].get_value(sponge)
 
-  # Then soak the sponge under the water
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.SOAK_UNDER, sink):
-    env.step(action)
-  assert sponge.states[object_states.Saturated].get_value(water_system)
+    # Then soak the sponge under the water
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.SOAK_UNDER, sink):
+      env.step(action)
+    assert sponge.states[object_states.Saturated].get_value(water_system)
 
-# def test_soak_inside():
-#    pass
+  # def test_soak_inside():
+  #    pass
 
-@pytest.mark.skip(reason="primitives are broken")
-def test_wipe(env, prim_gen, sponge, sink, countertop):
-  # Some pre-assertions
-  water_system = get_system("water", force_active=True)
-  assert not sponge.states[object_states.Saturated].get_value(water_system)
-  assert not sink.states[object_states.ToggledOn].get_value()
+  @pytest.mark.skip(reason="primitives are broken")
+  def test_wipe(self, env, prim_gen, sponge, sink, countertop):
+    # Some pre-assertions
+    water_system = get_system("water", force_active=True)
+    assert not sponge.states[object_states.Saturated].get_value(water_system)
+    assert not sink.states[object_states.ToggledOn].get_value()
 
-  # Dirty the countertop as the setup
-  mud_system = get_system("mud", force_active=True)
-  countertop.states[object_states.Covered].set_value(mud_system, True)
-  assert countertop.states[object_states.Covered].get_value(mud_system)
+    # Dirty the countertop as the setup
+    mud_system = get_system("mud", force_active=True)
+    countertop.states[object_states.Covered].set_value(mud_system, True)
+    assert countertop.states[object_states.Covered].get_value(mud_system)
 
-  # First toggle on the sink
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.TOGGLE_ON, sink):
-    env.step(action)
-  assert sink.states[object_states.ToggledOn].get_value()
+    # First toggle on the sink
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.TOGGLE_ON, sink):
+      env.step(action)
+    assert sink.states[object_states.ToggledOn].get_value()
 
-  # Then grasp the sponge
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, sponge):
-    env.step(action)
-  assert robot.states[object_states.IsGrasping].get_value(sponge)
+    # Then grasp the sponge
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, sponge):
+      env.step(action)
+    assert robot.states[object_states.IsGrasping].get_value(sponge)
 
-  # Then soak the sponge under the water
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.SOAK_UNDER, sink):
-    env.step(action)
-  assert sponge.states[object_states.Saturated].get_value(water_system)
+    # Then soak the sponge under the water
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.SOAK_UNDER, sink):
+      env.step(action)
+    assert sponge.states[object_states.Saturated].get_value(water_system)
 
-  # Wipe the countertop with the sponge
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.WIPE, countertop):
-    env.step(action)
-  assert not countertop.states[object_states.Covered].get_value(mud_system)
+    # Wipe the countertop with the sponge
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.WIPE, countertop):
+      env.step(action)
+    assert not countertop.states[object_states.Covered].get_value(mud_system)
 
-@pytest.mark.skip(reason="primitives are broken")
-def test_cut(env, prim_gen, apple, knife, countertop):
-  # assert not apple.states[object_states.Cut].get_value(knife)
-  print("Grasping knife")
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, knife):
-    env.step(action)
-  for _ in range(60): env.step(prim_gen._empty_action())
-  print("Cutting apple")
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.CUT, apple):
-    env.step(action)
-  for _ in range(60): env.step(prim_gen._empty_action())
-  print("Putting knife back on countertop")
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.PLACE_ON_TOP, countertop):
-    env.step(action)
+  @pytest.mark.skip(reason="primitives are broken")
+  def test_cut(self, env, prim_gen, apple, knife, countertop):
+    # assert not apple.states[object_states.Cut].get_value(knife)
+    print("Grasping knife")
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, knife):
+      env.step(action)
+    for _ in range(60): env.step(prim_gen._empty_action())
+    print("Cutting apple")
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.CUT, apple):
+      env.step(action)
+    for _ in range(60): env.step(prim_gen._empty_action())
+    print("Putting knife back on countertop")
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.PLACE_ON_TOP, countertop):
+      env.step(action)
 
-def test_persistent_sticky_grasping(env, robot, prim_gen, apple):
-  assert not robot.states[object_states.IsGrasping].get_value(apple)
-  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, apple):
-    env.step(action)
-  assert robot.states[object_states.IsGrasping].get_value(apple)
-  state = og.sim.dump_state()
-  og.sim.stop()
-  og.sim.play()
-  og.sim.load_state(state)
-  assert robot.states[object_states.IsGrasping].get_value(apple)
+  def test_persistent_sticky_grasping(self, env, robot, prim_gen, apple):
+    assert not robot.states[object_states.IsGrasping].get_value(apple)
+    for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, apple):
+      env.step(action)
+    assert robot.states[object_states.IsGrasping].get_value(apple)
+    state = og.sim.dump_state()
+    og.sim.stop()
+    og.sim.play()
+    og.sim.load_state(state)
+    assert robot.states[object_states.IsGrasping].get_value(apple)
 
-  for _ in range(10):
-    env.step(prim_gen._empty_action())
+    for _ in range(10):
+      env.step(prim_gen._empty_action())
 
-  assert robot.states[object_states.IsGrasping].get_value(apple)
+    assert robot.states[object_states.IsGrasping].get_value(apple)
 
-# def test_place_near_heating_element():
-#    pass
+  # def test_place_near_heating_element():
+  #    pass
 
-# def test_wait_for_cooked():
-#    pass
+  # def test_wait_for_cooked():
+  #    pass
+
+  def teardown_class(cls):
+    og.sim.clear()
 
 def main():
   env = start_env()

--- a/tests/test_symbolic_primitives.py
+++ b/tests/test_symbolic_primitives.py
@@ -44,7 +44,7 @@ def start_env():
         "rigid_trunk": False,
         "default_trunk_offset": 0.365,
         "default_arm_pose": "diagonal30",
-        "reset_joint_pos": "tuck",
+        "default_reset_mode": "tuck",
         "controller_config": {
           "base": {
             "name": "DifferentialDriveController"

--- a/tests/test_symbolic_primitives.py
+++ b/tests/test_symbolic_primitives.py
@@ -285,6 +285,22 @@ def test_cut(env, prim_gen, apple, knife, countertop):
   for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.PLACE_ON_TOP, countertop):
     env.step(action)
 
+def test_persistent_sticky_grasping(env, robot, prim_gen, apple):
+  assert not robot.states[object_states.IsGrasping].get_value(apple)
+  for action in prim_gen.apply_ref(SymbolicSemanticActionPrimitiveSet.GRASP, apple):
+    env.step(action)
+  assert robot.states[object_states.IsGrasping].get_value(apple)
+  state = og.sim.dump_state()
+  og.sim.stop()
+  og.sim.play()
+  og.sim.load_state(state)
+  assert robot.states[object_states.IsGrasping].get_value(apple)
+
+  for _ in range(10):
+    env.step(prim_gen._empty_action())
+
+  assert robot.states[object_states.IsGrasping].get_value(apple)
+
 # def test_place_near_heating_element():
 #    pass
 


### PR DESCRIPTION
The problem here was the `ag_obj_constraint_params` stored in the dumped state points to the robot's `self._ag_obj_constraint_params`. When we try to load the dumped state, we would call `_release_grasp`, which empties `self._ag_obj_constraint_params` together with the `ag_obj_constraint_params` in the state. 