### PR TITLE
lazy access of gm values

### DIFF
--- a/omnigibson/__init__.py
+++ b/omnigibson/__init__.py
@@ -31,8 +31,6 @@ nest_asyncio.apply()
 
 __version__ = "0.2.1"
 
-log.setLevel(logging.DEBUG if gm.DEBUG else logging.INFO)
-
 root_path = os.path.dirname(os.path.realpath(__file__))
 
 # Store paths to example configs

--- a/omnigibson/envs/env_base.py
+++ b/omnigibson/envs/env_base.py
@@ -3,7 +3,6 @@ import numpy as np
 from copy import deepcopy
 
 import omnigibson as og
-from omnigibson.objects import REGISTERED_OBJECTS
 from omnigibson.robots import REGISTERED_ROBOTS
 from omnigibson.scene_graphs.graph_builder import SceneGraphBuilder
 from omnigibson.simulator import launch_simulator
@@ -253,6 +252,7 @@ class Environment(gym.Env, GymObservable, Recreatable):
                 obj_config["name"] = f"obj{i}"
             # Pop the desired position and orientation
             position, orientation = obj_config.pop("position", None), obj_config.pop("orientation", None)
+            from omnigibson.objects import REGISTERED_OBJECTS
             # Make sure robot exists, grab its corresponding kwargs, and create / import the robot
             obj = create_class_from_registry_and_config(
                 cls_name=obj_config["type"],

--- a/omnigibson/objects/dataset_object.py
+++ b/omnigibson/objects/dataset_object.py
@@ -12,9 +12,9 @@ import omnigibson as og
 import omnigibson.lazy as lazy
 from omnigibson.macros import gm
 from omnigibson.objects.usd_object import USDObject
-from omnigibson.utils.constants import AVERAGE_CATEGORY_SPECS, DEFAULT_JOINT_FRICTION, SPECIAL_JOINT_FRICTIONS, JointType
+from omnigibson.utils.constants import DEFAULT_JOINT_FRICTION, SPECIAL_JOINT_FRICTIONS, JointType
 import omnigibson.utils.transform_utils as T
-from omnigibson.utils.asset_utils import get_all_object_category_models
+from omnigibson.utils.asset_utils import get_all_object_category_models, get_og_avg_category_specs
 from omnigibson.utils.constants import PrimType
 from omnigibson.macros import gm, create_module_macros
 from omnigibson.utils.ui_utils import create_module_logger
@@ -590,7 +590,8 @@ class DatasetObject(USDObject):
         Returns:
             None or dict: Average object information based on its category
         """
-        return AVERAGE_CATEGORY_SPECS.get(self.category, None)
+        avg_specs = get_og_avg_category_specs()
+        return avg_specs.get(self.category, None)
 
     def _create_prim_with_same_kwargs(self, prim_path, name, load_config):
         # Add additional kwargs (bounding_box is already captured in load_config)

--- a/omnigibson/scenes/scene_base.py
+++ b/omnigibson/scenes/scene_base.py
@@ -24,9 +24,6 @@ log = create_module_logger(module_name=__name__)
 # Create settings for this module
 m = create_module_macros(module_path=__file__)
 
-# Default texture to use for skybox
-m.DEFAULT_SKYBOX_TEXTURE = f"{gm.ASSET_PATH}/models/background/sky.jpg"
-
 # Global dicts that will contain mappings
 REGISTERED_SCENES = dict()
 
@@ -192,13 +189,16 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
             self._skybox = LightObject(
                 prim_path="/World/skybox",
                 name="skybox",
+                category="background",
                 light_type="Dome",
                 intensity=1500,
                 fixed_base=True,
             )
             og.sim.import_object(self._skybox, register=False)
             self._skybox.color = (1.07, 0.85, 0.61)
-            self._skybox.texture_file_path = m.DEFAULT_SKYBOX_TEXTURE
+            # Default texture to use for skybox
+            default_skybox_texture = f"{gm.ASSET_PATH}/models/background/sky.jpg"
+            self._skybox.texture_file_path = default_skybox_texture
 
     def _load_objects_from_scene_file(self):
         """

--- a/omnigibson/simulator.py
+++ b/omnigibson/simulator.py
@@ -150,6 +150,9 @@ def _launch_app():
     return app
 
 
+
+    log.setLevel(logging.DEBUG if gm.DEBUG else logging.INFO)
+
 def launch_simulator(*args, **kwargs):
     if not og.app:
         og.app = _launch_app()
@@ -1375,6 +1378,10 @@ def launch_simulator(*args, **kwargs):
             return self._scene.deserialize(state=state), self._scene.state_size
 
     if not og.sim:
+        
+        from omnigibson.systems.system_base import import_og_systems
+        # Import all OG systems from dataset
+        import_og_systems()
         og.sim = Simulator(*args, **kwargs)
 
         print()

--- a/omnigibson/systems/__init__.py
+++ b/omnigibson/systems/__init__.py
@@ -3,6 +3,3 @@ from omnigibson.systems.system_base import get_system, is_system_active, is_visu
     remove_callback_on_system_init, remove_callback_on_system_clear, import_og_systems
 from omnigibson.systems.micro_particle_system import *
 from omnigibson.systems.macro_particle_system import *
-
-# Import all OG systems from dataset
-import_og_systems()

--- a/omnigibson/utils/constants.py
+++ b/omnigibson/utils/constants.py
@@ -148,7 +148,6 @@ class JointType:
 
 # Object category specs
 AVERAGE_OBJ_DENSITY = 67.0
-AVERAGE_CATEGORY_SPECS = get_og_avg_category_specs()
 
 
 def get_collision_group_mask(groups_to_exclude=[]):


### PR DESCRIPTION
#603 
This PR removes eager uses of things like gm.DATASET_PATH e.g. in loading systems so that these values can be changed at runtime before initializing env. 

Note: this PR needs to wait until PR #594 gets merged because we need some refactoring from there. 