### PR TITLE
Compute tight base-aligned bounding boxes dynamically instead of using loose metadata

### DIFF
--- a/omnigibson/objects/dataset_object.py
+++ b/omnigibson/objects/dataset_object.py
@@ -1,12 +1,6 @@
-import itertools
 import math
 import os
-import stat
-import cv2
 import numpy as np
-
-import trimesh
-from scipy.spatial.transform import Rotation
 
 import omnigibson as og
 import omnigibson.lazy as lazy
@@ -436,93 +430,6 @@ class DatasetObject(USDObject):
                         scales[child_name] = scale_in_child_lf
 
         return scales
-
-    def get_base_aligned_bbox(self, link_name=None, visual=False, xy_aligned=False):
-        """
-        Get a bounding box for this object that's axis-aligned in the object's base frame.
-
-        Args:
-            link_name (None or str): If specified, only get the bbox for the given link
-            visual (bool): Whether to aggregate the bounding boxes from the visual meshes. Otherwise, will use
-                collision meshes
-            xy_aligned (bool): Whether to align the bounding box to the global XY-plane
-
-        Returns:
-            4-tuple:
-                - 3-array: (x,y,z) bbox center position in world frame
-                - 3-array: (x,y,z,w) bbox quaternion orientation in world frame
-                - 3-array: (x,y,z) bbox extent in desired frame
-                - 3-array: (x,y,z) bbox center in desired frame
-        """
-        # Get the base position transform.
-        pos, orn = self.get_position_orientation()
-        base_frame_to_world = T.pose2mat((pos, orn))
-
-        # Compute the world-to-base frame transform.
-        world_to_base_frame = trimesh.transformations.inverse_matrix(base_frame_to_world)
-
-        # Grab the corners of all the different links' bounding boxes. We will later fit a bounding box to
-        # this set of points to get our final, base-frame bounding box.
-        points = []
-
-        if self.prim_type == PrimType.CLOTH:
-            particle_contact_offset = self.root_link.cloth_system.particle_contact_offset
-            particle_positions = self.root_link.compute_particle_positions()
-            particles_in_world_frame = np.concatenate([
-                particle_positions - particle_contact_offset,
-                particle_positions + particle_contact_offset
-            ], axis=0)
-            points.extend(trimesh.transformations.transform_points(particles_in_world_frame, world_to_base_frame))
-        else:
-            links = {link_name: self._links[link_name]} if link_name is not None else self._links
-            for link_name, link in links.items():
-                if visual:
-                    hull_points = link.visual_boundary_points_world
-                else:
-                    hull_points = link.collision_boundary_points_world
-
-                if hull_points is not None:
-                    points.extend(hull_points)
-
-        if xy_aligned:
-            # If the user requested an XY-plane aligned bbox, convert everything to that frame.
-            # The desired frame is same as the base_com frame with its X/Y rotations removed.
-            translate = trimesh.transformations.translation_from_matrix(base_frame_to_world)
-
-            # To find the rotation that this transform does around the Z axis, we rotate the [1, 0, 0] vector by it
-            # and then take the arctangent of its projection onto the XY plane.
-            rotated_X_axis = base_frame_to_world[:3, 0]
-            rotation_around_Z_axis = np.arctan2(rotated_X_axis[1], rotated_X_axis[0])
-            xy_aligned_base_com_to_world = trimesh.transformations.compose_matrix(
-                translate=translate, angles=[0, 0, rotation_around_Z_axis]
-            )
-
-            # We want to move our points to this frame as well.
-            world_to_xy_aligned_base_com = trimesh.transformations.inverse_matrix(xy_aligned_base_com_to_world)
-            base_com_to_xy_aligned_base_com = np.dot(world_to_xy_aligned_base_com, base_frame_to_world)
-            points = trimesh.transformations.transform_points(points, base_com_to_xy_aligned_base_com)
-
-            # Finally update our desired frame.
-            desired_frame_to_world = xy_aligned_base_com_to_world
-        else:
-            # Default desired frame is base CoM frame.
-            desired_frame_to_world = base_frame_to_world
-
-        # TODO: Implement logic to allow tight bounding boxes that don't necessarily have to match the base frame.
-        # All points are now in the desired frame: either the base CoM or the xy-plane-aligned base CoM.
-        # Now fit a bounding box to all the points by taking the minimum/maximum in the desired frame.
-        aabb_min_in_desired_frame = np.amin(points, axis=0)
-        aabb_max_in_desired_frame = np.amax(points, axis=0)
-        bbox_center_in_desired_frame = (aabb_min_in_desired_frame + aabb_max_in_desired_frame) / 2
-        bbox_extent_in_desired_frame = aabb_max_in_desired_frame - aabb_min_in_desired_frame
-
-        # Transform the center to the world frame.
-        bbox_center_in_world = trimesh.transformations.transform_points(
-            [bbox_center_in_desired_frame], desired_frame_to_world
-        )[0]
-        bbox_orn_in_world = Rotation.from_matrix(desired_frame_to_world[:3, :3]).as_quat()
-
-        return bbox_center_in_world, bbox_orn_in_world, bbox_extent_in_desired_frame, bbox_center_in_desired_frame
 
     @property
     def avg_obj_dims(self):

--- a/omnigibson/objects/object_base.py
+++ b/omnigibson/objects/object_base.py
@@ -357,7 +357,7 @@ class BaseObject(EntityPrim, Registerable, metaclass=ABCMeta):
             desired_frame_to_world = base_frame_to_world
 
         # Compute the world-to-base frame transform.
-        world_to_desired_frame = trimesh.transformations.inverse_matrix(desired_frame_to_world)
+        world_to_desired_frame = np.linalg.inv(desired_frame_to_world)
 
         # Grab all the world-frame points corresponding to the object's visual or collision hulls.
         points_in_world = []

--- a/omnigibson/objects/object_base.py
+++ b/omnigibson/objects/object_base.py
@@ -1,6 +1,8 @@
 from abc import ABCMeta
 import numpy as np
 from collections.abc import Iterable
+import trimesh
+from scipy.spatial.transform import Rotation
 
 import omnigibson as og
 import omnigibson.lazy as lazy
@@ -10,6 +12,7 @@ from omnigibson.prims.entity_prim import EntityPrim
 from omnigibson.utils.python_utils import Registerable, classproperty, get_uuid
 from omnigibson.utils.constants import PrimType, semantic_class_name_to_id
 from omnigibson.utils.ui_utils import create_module_logger, suppress_omni_log
+import omnigibson.utils.transform_utils as T
 
 
 # Global dicts that will contain mappings
@@ -311,6 +314,89 @@ class BaseObject(EntityPrim, Registerable, metaclass=ABCMeta):
 
         # Update internal value
         self._highlighted = enabled
+
+    def get_base_aligned_bbox(self, link_name=None, visual=False, xy_aligned=False):
+        """
+        Get a bounding box for this object that's axis-aligned in the object's base frame.
+
+        Args:
+            link_name (None or str): If specified, only get the bbox for the given link
+            visual (bool): Whether to aggregate the bounding boxes from the visual meshes. Otherwise, will use
+                collision meshes
+            xy_aligned (bool): Whether to align the bounding box to the global XY-plane
+
+        Returns:
+            4-tuple:
+                - 3-array: (x,y,z) bbox center position in world frame
+                - 3-array: (x,y,z,w) bbox quaternion orientation in world frame
+                - 3-array: (x,y,z) bbox extent in desired frame
+                - 3-array: (x,y,z) bbox center in desired frame
+        """
+        # Get the base position transform.
+        pos, orn = self.get_position_orientation()
+        base_frame_to_world = T.pose2mat((pos, orn))
+
+        # Prepare the desired frame.
+        if xy_aligned:
+            # If the user requested an XY-plane aligned bbox, convert everything to that frame.
+            # The desired frame is same as the base_com frame with its X/Y rotations removed.
+            translate = trimesh.transformations.translation_from_matrix(base_frame_to_world)
+
+            # To find the rotation that this transform does around the Z axis, we rotate the [1, 0, 0] vector by it
+            # and then take the arctangent of its projection onto the XY plane.
+            rotated_X_axis = base_frame_to_world[:3, 0]
+            rotation_around_Z_axis = np.arctan2(rotated_X_axis[1], rotated_X_axis[0])
+            xy_aligned_base_com_to_world = trimesh.transformations.compose_matrix(
+                translate=translate, angles=[0, 0, rotation_around_Z_axis]
+            )
+
+            # Finally update our desired frame.
+            desired_frame_to_world = xy_aligned_base_com_to_world
+        else:
+            # Default desired frame is base CoM frame.
+            desired_frame_to_world = base_frame_to_world
+
+        # Compute the world-to-base frame transform.
+        world_to_desired_frame = trimesh.transformations.inverse_matrix(desired_frame_to_world)
+
+        # Grab all the world-frame points corresponding to the object's visual or collision hulls.
+        points_in_world = []
+        if self.prim_type == PrimType.CLOTH:
+            particle_contact_offset = self.root_link.cloth_system.particle_contact_offset
+            particle_positions = self.root_link.compute_particle_positions()
+            particles_in_world_frame = np.concatenate([
+                particle_positions - particle_contact_offset,
+                particle_positions + particle_contact_offset
+            ], axis=0)
+            points_in_world.extend(particles_in_world_frame)
+        else:
+            links = {link_name: self._links[link_name]} if link_name is not None else self._links
+            for link_name, link in links.items():
+                if visual:
+                    hull_points = link.visual_boundary_points_world
+                else:
+                    hull_points = link.collision_boundary_points_world
+
+                if hull_points is not None:
+                    points_in_world.extend(hull_points)
+
+        # Move the points to the desired frame
+        points = trimesh.transformations.transform_points(points_in_world, world_to_desired_frame)
+
+        # All points are now in the desired frame: either the base CoM or the xy-plane-aligned base CoM.
+        # Now fit a bounding box to all the points by taking the minimum/maximum in the desired frame.
+        aabb_min_in_desired_frame = np.amin(points, axis=0)
+        aabb_max_in_desired_frame = np.amax(points, axis=0)
+        bbox_center_in_desired_frame = (aabb_min_in_desired_frame + aabb_max_in_desired_frame) / 2
+        bbox_extent_in_desired_frame = aabb_max_in_desired_frame - aabb_min_in_desired_frame
+
+        # Transform the center to the world frame.
+        bbox_center_in_world = trimesh.transformations.transform_points(
+            [bbox_center_in_desired_frame], desired_frame_to_world
+        )[0]
+        bbox_orn_in_world = Rotation.from_matrix(desired_frame_to_world[:3, :3]).as_quat()
+
+        return bbox_center_in_world, bbox_orn_in_world, bbox_extent_in_desired_frame, bbox_center_in_desired_frame
 
     @classproperty
     def _do_not_register_classes(cls):

--- a/omnigibson/prims/entity_prim.py
+++ b/omnigibson/prims/entity_prim.py
@@ -1245,20 +1245,8 @@ class EntityPrim(XFormPrim):
             aabb_lo, aabb_hi = np.min(particle_positions, axis=0) - particle_contact_offset, \
                                np.max(particle_positions, axis=0) + particle_contact_offset
         else:
-            points_world = []
-            for link in self._links.values():
-                hull_points = link.collision_boundary_points
-                if hull_points is None:
-                    continue
-                
-                position, orientation = link.get_position_orientation()
-                scale = link.scale
-                points_scaled = hull_points * scale
-                points_rotated = np.dot(T.quat2mat(orientation), points_scaled.T).T
-                points_transformed = points_rotated + position
-                points_world.append(points_transformed)
-
-            all_points = np.concatenate(points_world, axis=0)
+            points_world = [link.collision_boundary_points_world for link in self._links.values()]
+            all_points = np.concatenate([p for p in points_world if p is not None], axis=0)
             aabb_lo = np.min(all_points, axis=0)
             aabb_hi = np.max(all_points, axis=0)
         return aabb_lo, aabb_hi

--- a/omnigibson/prims/xform_prim.py
+++ b/omnigibson/prims/xform_prim.py
@@ -10,6 +10,7 @@ from omnigibson.utils.usd_utils import PoseAPI
 import omnigibson.utils.transform_utils as T
 from scipy.spatial.transform import Rotation as R
 from omnigibson.macros import gm
+import trimesh.transformations
 
 class XFormPrim(BasePrim):
     """
@@ -317,6 +318,9 @@ class XFormPrim(BasePrim):
         Returns the scaled transform of this prim.
         """
         return PoseAPI.get_world_pose_with_scale(self._prim_path)
+
+    def transform_local_points_to_world(self, points):
+        return trimesh.transformations.transform_points(points, self.scaled_transform)
 
     @property
     def scale(self):

--- a/omnigibson/scene_graphs/graph_builder.py
+++ b/omnigibson/scene_graphs/graph_builder.py
@@ -187,7 +187,7 @@ class SceneGraphBuilder(object):
 
             # Get the bounding box.
             if hasattr(obj, "get_base_aligned_bbox"):
-                bbox_center, bbox_orn, bbox_extent, _ = obj.get_base_aligned_bbox(visual=True, fallback_to_aabb=True)
+                bbox_center, bbox_orn, bbox_extent, _ = obj.get_base_aligned_bbox(visual=True)
                 bbox_pose = T.pose2mat((bbox_center, bbox_orn))
             else:
                 bbox_pose, bbox_extent = _formatted_aabb(obj)


### PR DESCRIPTION
This switches the base aligned bb mechanism to use Hang's new points system rather than relying on offline metadata. I also clean up some code and fix a small possible bug in the existing link-to-world transformation system.