### PR TITLE
Don't mess up toggle button offsets

### DIFF
--- a/omnigibson/object_states/toggle.py
+++ b/omnigibson/object_states/toggle.py
@@ -115,9 +115,6 @@ class ToggledOn(AbsoluteObjectState, BooleanStateMixin, LinkBasedStateMixin, Upd
         self.visual_marker.initialize()
         self.visual_marker.visible = True
 
-        # Make sure the marker isn't translated at all
-        self.visual_marker.set_local_pose(position=np.zeros(3), orientation=np.array([0, 0, 0, 1.0]))
-
         # Store the projection mesh's IDs
         projection_mesh_ids = lazy.pxr.PhysicsSchemaTools.encodeSdfPath(self.visual_marker.prim_path)
 


### PR DESCRIPTION
This is one of those things where I don't know what the code is supposed to be doing but it's doing something wrong currently (objects like charcoal_grill-crdaeu end up with their toggleable meshes moved to the wrong spot)