### PR TITLE
Optimize segmentation remapping performance

### DIFF
--- a/omnigibson/sensors/vision_sensor.py
+++ b/omnigibson/sensors/vision_sensor.py
@@ -310,8 +310,6 @@ class VisionSensor(BaseSensor):
 
             assert replicator_mapping[key] in semantic_class_id_to_name().values(), f"Class {val['class']} does not exist in the semantic class name to id mapping!"
 
-        assert set(np.unique(img)).issubset(set(replicator_mapping.keys())), "Semantic segmentation image does not match the original id_to_labels mapping."
-
         return VisionSensor.SEMANTIC_REMAPPER.remap(replicator_mapping, semantic_class_id_to_name(), img)
 
     def _remap_instance_segmentation(self, img, id_to_labels, semantic_img, semantic_labels, id=False):
@@ -371,7 +369,8 @@ class VisionSensor(BaseSensor):
         # Handle the cases for MicroPhysicalParticleSystem (FluidSystem, GranularSystem).
         # They show up in the image, but not in the info (id_to_labels).
         # We identify these values, find the corresponding semantic label (system name), and add the mapping.
-        for key, img_idx in zip(*np.unique(img, return_index=True)):
+        image_keys, key_indices = np.unique(img, return_index=True)
+        for key, img_idx in zip(image_keys, key_indices):
             if str(key) not in id_to_labels:
                 semantic_label = semantic_img.flatten()[img_idx]
                 assert semantic_label in semantic_labels, f"Semantic map value {semantic_label} is not in the semantic labels!"
@@ -397,9 +396,7 @@ class VisionSensor(BaseSensor):
         registry = VisionSensor.INSTANCE_ID_REGISTRY if id else VisionSensor.INSTANCE_REGISTRY
         remapper = VisionSensor.INSTANCE_ID_REMAPPER if id else VisionSensor.INSTANCE_REMAPPER
 
-        assert set(np.unique(img)).issubset(set(replicator_mapping.keys())), "Instance segmentation image does not match the original id_to_labels mapping."
-
-        return remapper.remap(replicator_mapping, registry, img)
+        return remapper.remap(replicator_mapping, registry, img, image_keys)
 
     def _register_instance(self, instance_name, id=False):
         registry = VisionSensor.INSTANCE_ID_REGISTRY if id else VisionSensor.INSTANCE_REGISTRY

--- a/omnigibson/sensors/vision_sensor.py
+++ b/omnigibson/sensors/vision_sensor.py
@@ -310,7 +310,10 @@ class VisionSensor(BaseSensor):
 
             assert replicator_mapping[key] in semantic_class_id_to_name().values(), f"Class {val['class']} does not exist in the semantic class name to id mapping!"
 
-        return VisionSensor.SEMANTIC_REMAPPER.remap(replicator_mapping, semantic_class_id_to_name(), img)
+        image_keys = np.unique(img)
+        assert set(image_keys).issubset(set(replicator_mapping.keys())), "Semantic segmentation image does not match the original id_to_labels mapping."
+
+        return VisionSensor.SEMANTIC_REMAPPER.remap(replicator_mapping, semantic_class_id_to_name(), img, image_keys)
 
     def _remap_instance_segmentation(self, img, id_to_labels, semantic_img, semantic_labels, id=False):
         """
@@ -395,6 +398,8 @@ class VisionSensor(BaseSensor):
 
         registry = VisionSensor.INSTANCE_ID_REGISTRY if id else VisionSensor.INSTANCE_REGISTRY
         remapper = VisionSensor.INSTANCE_ID_REMAPPER if id else VisionSensor.INSTANCE_REMAPPER
+        
+        assert set(image_keys).issubset(set(replicator_mapping.keys())), "Instance segmentation image does not match the original id_to_labels mapping."
 
         return remapper.remap(replicator_mapping, registry, img, image_keys)
 

--- a/omnigibson/utils/vision_utils.py
+++ b/omnigibson/utils/vision_utils.py
@@ -75,7 +75,7 @@ class Remapper:
         self.key_array = np.array([], dtype=np.uint32)
         self.known_ids = set()
 
-    def remap(self, old_mapping, new_mapping, image):
+    def remap(self, old_mapping, new_mapping, image, image_keys=None):
         """
         Remaps values in the given image from old_mapping to new_mapping using an efficient key_array.
         If the image contains values that are not in old_mapping, they are remapped to the value in new_mapping
@@ -87,13 +87,13 @@ class Remapper:
             new_mapping (dict): The new mapping dictionary that maps another set of image values to labels,
                 e.g. {5: 'desk', 7: 'chair', 100: 'unlabelled'}.
             image (np.ndarray): The 2D image to remap, e.g. [[1, 3], [1, 2]].
+            image_keys (np.ndarray): The unique keys in the image, e.g. [1, 2, 3].
         
         Returns:
             np.ndarray: The remapped image, e.g. [[5,100],[5,7]].
             dict: The remapped labels dictionary, e.g. {5: 'desk', 7: 'chair', 100: 'unlabelled'}.
         """
-        # Make sure that max uint32 doesn't match any value in the new mapping
-        assert np.all(np.array(list(new_mapping.keys())) != np.iinfo(np.uint32).max), "New mapping contains default unmapped value!"
+        # TODO: we need to make sure that max uint32 doesn't match any value in the new mapping; removing assertion for performance
         image_max_key = np.max(image)
         key_array_max_key =  len(self.key_array) - 1
         if image_max_key > key_array_max_key:
@@ -116,7 +116,7 @@ class Remapper:
         # For all the values that exist in the image but not in old_mapping.keys(), we map them to whichever key in
         # new_mapping that equals to 'unlabelled'. This is needed because some values in the image don't necessarily
         # show up in the old_mapping, i.e. particle systems.
-        for key in np.unique(image):
+        for key in np.unique(image) if image_keys is None else image_keys:
             if key not in old_mapping.keys():
                 new_key = next((k for k, v in new_mapping.items() if v == 'unlabelled'), None)
                 assert new_key is not None, f"Could not find a new key for label 'unlabelled' in new_mapping!"

--- a/omnigibson/utils/vision_utils.py
+++ b/omnigibson/utils/vision_utils.py
@@ -93,7 +93,8 @@ class Remapper:
             np.ndarray: The remapped image, e.g. [[5,100],[5,7]].
             dict: The remapped labels dictionary, e.g. {5: 'desk', 7: 'chair', 100: 'unlabelled'}.
         """
-        # TODO: we need to make sure that max uint32 doesn't match any value in the new mapping; removing assertion for performance
+        # Make sure that max uint32 doesn't match any value in the new mapping
+        assert np.all(np.array(list(new_mapping.keys())) != np.iinfo(np.uint32).max), "New mapping contains default unmapped value!"
         image_max_key = np.max(image)
         key_array_max_key =  len(self.key_array) - 1
         if image_max_key > key_array_max_key:


### PR DESCRIPTION
Avoid duplicated np.unique calls for segmentation remapping performance. With these changes, remapping now only takes around 50% time compared to what we had before.
![image](https://github.com/StanfordVL/OmniGibson/assets/60046203/891e084e-737b-497a-a04a-210ef11d755f)
