### PR TITLE
Implement centralized control getter/setter for fast access in parallel envs

### DIFF
--- a/omnigibson/controllers/joint_controller.py
+++ b/omnigibson/controllers/joint_controller.py
@@ -187,7 +187,7 @@ class JointController(LocomotionController, ManipulationController, GripperContr
             else:  # effort
                 u = target
 
-            dof_idxs_mat = tuple(np.meshgrid(self.dof_idx, self.dof_idx))
+            dof_idxs_mat = np.ix_(self.dof_idx, self.dof_idx)
             mm = control_dict["mass_matrix"][dof_idxs_mat]
             u = np.dot(mm, u)
 

--- a/omnigibson/objects/controllable_object.py
+++ b/omnigibson/objects/controllable_object.py
@@ -503,15 +503,15 @@ class ControllableObject(BaseObject):
         # set the targets for joints
         if using_pos:
             ControllableObjectViewAPI.set_joint_position_targets(
-                positions=np.array(pos_vec), indices=np.array(pos_idxs)
+                self.articulation_root_path, positions=np.array(pos_vec), indices=np.array(pos_idxs)
             )
         if using_vel:
             ControllableObjectViewAPI.set_joint_velocity_targets(
-                self.prim_path, velocities=np.array(vel_vec), indices=np.array(vel_idxs)
+                self.articulation_root_path, velocities=np.array(vel_vec), indices=np.array(vel_idxs)
             )
         if using_eff:
             ControllableObjectViewAPI.set_joint_efforts(
-                self.prim_path, efforts=np.array(eff_vec), indices=np.array(eff_idxs)
+                self.articulation_root_path, efforts=np.array(eff_vec), indices=np.array(eff_idxs)
             )
 
     def get_control_dict(self):
@@ -537,19 +537,28 @@ class ControllableObject(BaseObject):
         # removing the need for multiple reads and writes.
         # TODO: CachedFunctions can now be entirely removed since the API already implements caching.
         fcns = CachedFunctions()
-        fcns["_root_pos_quat"] = lambda: ControllableObjectViewAPI.get_position_orientation(self.prim_path)
+        fcns["_root_pos_quat"] = lambda: ControllableObjectViewAPI.get_position_orientation(self.articulation_root_path)
         fcns["root_pos"] = lambda: fcns["_root_pos_quat"][0]
         fcns["root_quat"] = lambda: fcns["_root_pos_quat"][1]
-        fcns["root_lin_vel"] = lambda: ControllableObjectViewAPI.get_linear_velocity(self.prim_path)
-        fcns["root_ang_vel"] = lambda: ControllableObjectViewAPI.get_angular_velocity(self.prim_path)
-        fcns["root_rel_lin_vel"] = lambda: ControllableObjectViewAPI.get_relative_linear_velocity(self.prim_path)
-        fcns["root_rel_ang_vel"] = lambda: ControllableObjectViewAPI.get_relative_angular_velocity(self.prim_path)
-        fcns["joint_position"] = lambda: ControllableObjectViewAPI.get_joint_positions(self.prim_path)
-        fcns["joint_velocity"] = lambda: ControllableObjectViewAPI.get_joint_velocities(self.prim_path)
-        fcns["joint_effort"] = lambda: ControllableObjectViewAPI.get_joint_efforts(self.prim_path)
-        fcns["mass_matrix"] = lambda: ControllableObjectViewAPI.get_mass_matrix(self.prim_path)
-        fcns["gravity_force"] = lambda: ControllableObjectViewAPI.get_generalized_gravity_forces(self.prim_path)
-        fcns["cc_force"] = lambda: ControllableObjectViewAPI.get_coriolis_and_centrifugal_forces(self.prim_path)
+        fcns["root_lin_vel"] = lambda: ControllableObjectViewAPI.get_linear_velocity(self.articulation_root_path)
+        fcns["root_ang_vel"] = lambda: ControllableObjectViewAPI.get_angular_velocity(self.articulation_root_path)
+        fcns["root_rel_lin_vel"] = lambda: ControllableObjectViewAPI.get_relative_linear_velocity(
+            self.articulation_root_path
+        )
+        fcns["root_rel_ang_vel"] = lambda: ControllableObjectViewAPI.get_relative_angular_velocity(
+            self.articulation_root_path
+        )
+        fcns["joint_position"] = lambda: ControllableObjectViewAPI.get_joint_positions(self.articulation_root_path)
+        fcns["joint_velocity"] = lambda: ControllableObjectViewAPI.get_joint_velocities(self.articulation_root_path)
+        fcns["joint_effort"] = lambda: ControllableObjectViewAPI.get_joint_efforts(self.articulation_root_path)
+        fcns["mass_matrix"] = lambda: ControllableObjectViewAPI.get_mass_matrix(self.articulation_root_path)
+        # TODO: Move gravity force computation dummy to this class instead of BaseRobot
+        fcns["gravity_force"] = lambda: ControllableObjectViewAPI.get_generalized_gravity_forces(
+            self.articulation_root_path if not self.fixed_base else self._dummy.articulation_root_path
+        )
+        fcns["cc_force"] = lambda: ControllableObjectViewAPI.get_coriolis_and_centrifugal_forces(
+            self.articulation_root_path
+        )
 
         return fcns
 

--- a/omnigibson/objects/controllable_object.py
+++ b/omnigibson/objects/controllable_object.py
@@ -146,14 +146,6 @@ class ControllableObject(BaseObject):
         self.reset()
         self.keep_still()
 
-        # If we haven't already created a physics callback, do so now so control gets updated every sim step
-        callback_name = f"{self.name}_controller_callback"
-        if not og.sim.physics_callback_exists(callback_name=callback_name):
-            og.sim.add_physics_callback(
-                callback_name=callback_name,
-                callback_fn=lambda x: self.step(),
-            )
-
     def load(self):
         # Run super first
         prim = super().load()

--- a/omnigibson/objects/controllable_object.py
+++ b/omnigibson/objects/controllable_object.py
@@ -9,6 +9,7 @@ from omnigibson.controllers.controller_base import ControlType
 from omnigibson.utils.python_utils import assert_valid_key, merge_nested_dicts, CachedFunctions
 from omnigibson.utils.constants import PrimType
 from omnigibson.utils.ui_utils import create_module_logger
+from omnigibson.utils.usd_utils import ControllableObjectViewAPI
 
 # Create module logger
 log = create_module_logger(module_name=__name__)
@@ -89,6 +90,16 @@ class ControllableObject(BaseObject):
         self._controllers = None
         self.dof_names_ordered = None
         self._control_enabled = True
+
+        if prim_path:
+            # If prim path is specified, assert that the last element starts with controllable_ to ensure that
+            # the object will be included in the ControllableObjectViewAPI.
+            assert prim_path.split("/")[-1].startswith(
+                "controllable_"
+            ), "If prim_path is specified, the last element of the path must start with 'controllable_'."
+        else:
+            # If prim path is not specified, set it to the default path, but prepend controllable.
+            prim_path = f"/World/controllable_{name}"
 
         # Run super init
         super().__init__(
@@ -372,7 +383,7 @@ class ControllableObject(BaseObject):
         u_vec, u_type_vec = self._postprocess_control(control=u_vec, control_type=u_type_vec)
 
         # Deploy control signals
-        self.deploy_control(control=u_vec, control_type=u_type_vec, indices=None, normalized=False)
+        self.deploy_control(control=u_vec, control_type=u_type_vec)
 
     def _postprocess_control(self, control, control_type):
         """
@@ -394,7 +405,7 @@ class ControllableObject(BaseObject):
         """
         return control, control_type
 
-    def deploy_control(self, control, control_type, indices=None, normalized=False):
+    def deploy_control(self, control, control_type):
         """
         Deploys control signals @control with corresponding @control_type on this entity.
 
@@ -459,8 +470,8 @@ class ControllableObject(BaseObject):
                 ), "Got mismatched control indices for a single joint!"
                 # Check to make sure all joints, control_types, and normalized as all the same over n-DOF for the joint
                 for group_name, group in zip(
-                    ("joints", "control_types", "normalized"),
-                    (self._dof_to_joints, control_type, normalized),
+                    ("joints", "control_types"),
+                    (self._dof_to_joints, control_type),
                 ):
                     assert (
                         len({group[indices[cur_indices_idx + i]] for i in range(joint_dof)}) == 1
@@ -499,15 +510,17 @@ class ControllableObject(BaseObject):
 
         # set the targets for joints
         if using_pos:
-            self.set_joint_positions(
-                positions=np.array(pos_vec), indices=np.array(pos_idxs), drive=True, normalized=normalized
+            ControllableObjectViewAPI.set_joint_position_targets(
+                positions=np.array(pos_vec), indices=np.array(pos_idxs)
             )
         if using_vel:
-            self.set_joint_velocities(
-                velocities=np.array(vel_vec), indices=np.array(vel_idxs), drive=True, normalized=normalized
+            ControllableObjectViewAPI.set_joint_velocity_targets(
+                self.prim_path, velocities=np.array(vel_vec), indices=np.array(vel_idxs)
             )
         if using_eff:
-            self.set_joint_efforts(efforts=np.array(eff_vec), indices=np.array(eff_idxs), normalized=normalized)
+            ControllableObjectViewAPI.set_joint_efforts(
+                self.prim_path, efforts=np.array(eff_vec), indices=np.array(eff_idxs)
+            )
 
     def get_control_dict(self):
         """
@@ -527,20 +540,24 @@ class ControllableObject(BaseObject):
                 - gravity_force: (n_dof,) per-joint generalized gravity forces
                 - cc_force: (n_dof,) per-joint centripetal and centrifugal forces
         """
+        # Note that everything here uses the ControllableObjectViewAPI because these are faster implementations of
+        # the functions that this class also implements. The API centralizes access for all of the robots in the scene
+        # removing the need for multiple reads and writes.
+        # TODO: CachedFunctions can now be entirely removed since the API already implements caching.
         fcns = CachedFunctions()
-        fcns["_root_pos_quat"] = self.get_position_orientation
+        fcns["_root_pos_quat"] = lambda: ControllableObjectViewAPI.get_position_orientation(self.prim_path)
         fcns["root_pos"] = lambda: fcns["_root_pos_quat"][0]
         fcns["root_quat"] = lambda: fcns["_root_pos_quat"][1]
-        fcns["root_lin_vel"] = self.get_linear_velocity
-        fcns["root_ang_vel"] = self.get_angular_velocity
-        fcns["root_rel_lin_vel"] = self.get_relative_linear_velocity
-        fcns["root_rel_ang_vel"] = self.get_relative_angular_velocity
-        fcns["joint_position"] = lambda: self.get_joint_positions(normalized=False)
-        fcns["joint_velocity"] = lambda: self.get_joint_velocities(normalized=False)
-        fcns["joint_effort"] = lambda: self.get_joint_efforts(normalized=False)
-        fcns["mass_matrix"] = lambda: self.get_mass_matrix(clone=False)
-        fcns["gravity_force"] = lambda: self.get_generalized_gravity_forces(clone=False)
-        fcns["cc_force"] = lambda: self.get_coriolis_and_centrifugal_forces(clone=False)
+        fcns["root_lin_vel"] = lambda: ControllableObjectViewAPI.get_linear_velocity(self.prim_path)
+        fcns["root_ang_vel"] = lambda: ControllableObjectViewAPI.get_angular_velocity(self.prim_path)
+        fcns["root_rel_lin_vel"] = lambda: ControllableObjectViewAPI.get_relative_linear_velocity(self.prim_path)
+        fcns["root_rel_ang_vel"] = lambda: ControllableObjectViewAPI.get_relative_angular_velocity(self.prim_path)
+        fcns["joint_position"] = lambda: ControllableObjectViewAPI.get_joint_positions(self.prim_path)
+        fcns["joint_velocity"] = lambda: ControllableObjectViewAPI.get_joint_velocities(self.prim_path)
+        fcns["joint_effort"] = lambda: ControllableObjectViewAPI.get_joint_efforts(self.prim_path)
+        fcns["mass_matrix"] = lambda: ControllableObjectViewAPI.get_mass_matrix(self.prim_path)
+        fcns["gravity_force"] = lambda: ControllableObjectViewAPI.get_generalized_gravity_forces(self.prim_path)
+        fcns["cc_force"] = lambda: ControllableObjectViewAPI.get_coriolis_and_centrifugal_forces(self.prim_path)
 
         return fcns
 

--- a/omnigibson/objects/controllable_object.py
+++ b/omnigibson/objects/controllable_object.py
@@ -424,18 +424,12 @@ class ControllableObject(BaseObject):
                 values. Expects a single bool for the entire @control. Default is False.
         """
         # Run sanity check
-        if indices is None:
-            assert len(control) == len(control_type) == self.n_dof, (
-                "Control signals, control types, and number of DOF should all be the same!"
-                "Got {}, {}, and {} respectively.".format(len(control), len(control_type), self.n_dof)
-            )
-            # Set indices manually so that we're standardized
-            indices = np.arange(self.n_dof)
-        else:
-            assert len(control) == len(control_type) == len(indices), (
-                "Control signals, control types, and indices should all be the same!"
-                "Got {}, {}, and {} respectively.".format(len(control), len(control_type), len(indices))
-            )
+        assert len(control) == len(control_type) == self.n_dof, (
+            "Control signals, control types, and number of DOF should all be the same!"
+            "Got {}, {}, and {} respectively.".format(len(control), len(control_type), self.n_dof)
+        )
+        # Set indices manually so that we're standardized
+        indices = np.arange(self.n_dof)
 
         # Standardize normalized input
         n_indices = len(indices)

--- a/omnigibson/prims/entity_prim.py
+++ b/omnigibson/prims/entity_prim.py
@@ -898,7 +898,7 @@ class EntityPrim(XFormPrim):
 
     def get_joint_efforts(self, normalized=False):
         """
-        Grabs this entity's joint efforts
+        Grabs this entity's "measured" joint efforts
 
         Args:
             normalized (bool): Whether returned values should be normalized to range [-1, 1] based on limits or not.
@@ -909,7 +909,7 @@ class EntityPrim(XFormPrim):
         # Run sanity checks -- make sure we are articulated
         assert self.n_joints > 0, "Tried to call method not intended for entity prim with no joints!"
 
-        joint_efforts = self._articulation_view.get_applied_joint_efforts().reshape(self.n_dof)
+        joint_efforts = self._articulation_view.get_measured_joint_efforts().reshape(self.n_dof)
 
         # Possibly normalize values when returning
         return self._normalize_efforts(efforts=joint_efforts) if normalized else joint_efforts

--- a/omnigibson/prims/joint_prim.py
+++ b/omnigibson/prims/joint_prim.py
@@ -621,7 +621,7 @@ class JointPrim(BasePrim):
         # Grab raw states
         pos = self._articulation_view.get_joint_positions(joint_indices=self.dof_indices)[0]
         vel = self._articulation_view.get_joint_velocities(joint_indices=self.dof_indices)[0]
-        effort = self._articulation_view.get_applied_joint_efforts(joint_indices=self.dof_indices)[0]
+        effort = self._articulation_view.get_measured_joint_efforts(joint_indices=self.dof_indices)[0]
 
         # Potentially normalize if requested
         if normalized:

--- a/omnigibson/prims/rigid_prim.py
+++ b/omnigibson/prims/rigid_prim.py
@@ -501,7 +501,7 @@ class RigidPrim(XFormPrim):
         """
         self._rigid_prim_view.set_densities([density])
 
-    @property
+    @cached_property
     def kinematic_only(self):
         """
         Returns:

--- a/omnigibson/robots/active_camera_robot.py
+++ b/omnigibson/robots/active_camera_robot.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from omnigibson.robots.robot_base import BaseRobot
 from omnigibson.utils.python_utils import classproperty
+from omnigibson.utils.usd_utils import ControllableObjectViewAPI
 
 
 class ActiveCameraRobot(BaseRobot):
@@ -35,8 +36,8 @@ class ActiveCameraRobot(BaseRobot):
         dic = super()._get_proprioception_dict()
 
         # Add camera pos info
-        joint_positions = self.get_joint_positions(normalized=False)
-        joint_velocities = self.get_joint_velocities(normalized=False)
+        joint_positions = ControllableObjectViewAPI.get_joint_positions(self.articulation_root_path)
+        joint_velocities = ControllableObjectViewAPI.get_joint_velocities(self.articulation_root_path)
         dic["camera_qpos"] = joint_positions[self.camera_control_idx]
         dic["camera_qpos_sin"] = np.sin(joint_positions[self.camera_control_idx])
         dic["camera_qpos_cos"] = np.cos(joint_positions[self.camera_control_idx])

--- a/omnigibson/robots/fetch.py
+++ b/omnigibson/robots/fetch.py
@@ -9,7 +9,7 @@ from omnigibson.robots.two_wheel_robot import TwoWheelRobot
 from omnigibson.utils.python_utils import assert_valid_key
 from omnigibson.utils.ui_utils import create_module_logger
 from omnigibson.utils.transform_utils import euler2quat
-from omnigibson.utils.usd_utils import JointType
+from omnigibson.utils.usd_utils import ControllableObjectViewAPI, JointType
 
 log = create_module_logger(module_name=__name__)
 
@@ -280,8 +280,8 @@ class Fetch(ManipulationRobot, TwoWheelRobot, ActiveCameraRobot):
         dic = super()._get_proprioception_dict()
 
         # Add trunk info
-        joint_positions = self.get_joint_positions(normalized=False)
-        joint_velocities = self.get_joint_velocities(normalized=False)
+        joint_positions = ControllableObjectViewAPI.get_joint_positions(self.articulation_root_path)
+        joint_velocities = ControllableObjectViewAPI.get_joint_velocities(self.articulation_root_path)
         dic["trunk_qpos"] = joint_positions[self.trunk_control_idx]
         dic["trunk_qvel"] = joint_velocities[self.trunk_control_idx]
 

--- a/omnigibson/robots/locomotion_robot.py
+++ b/omnigibson/robots/locomotion_robot.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 
 import numpy as np
+from omnigibson.utils.usd_utils import ControllableObjectViewAPI
 from transforms3d.euler import euler2quat
 from transforms3d.quaternions import qmult, quat2mat
 
@@ -39,8 +40,8 @@ class LocomotionRobot(BaseRobot):
     def _get_proprioception_dict(self):
         dic = super()._get_proprioception_dict()
 
-        joint_positions = self.get_joint_positions(normalized=False)
-        joint_velocities = self.get_joint_velocities(normalized=False)
+        joint_positions = ControllableObjectViewAPI.get_joint_positions(self.articulation_root_path)
+        joint_velocities = ControllableObjectViewAPI.get_joint_velocities(self.articulation_root_path)
 
         # Add base info
         dic["base_qpos"] = joint_positions[self.base_control_idx]

--- a/omnigibson/robots/manipulation_robot.py
+++ b/omnigibson/robots/manipulation_robot.py
@@ -325,7 +325,7 @@ class ManipulationRobot(BaseRobot):
                 new_obj_pose = new_eef_pose @ inv_original_eef_pose @ original_obj_pose
                 self._ag_obj_in_hand[arm].set_position_orientation(*T.mat2pose(hmat=new_obj_pose))
 
-    def deploy_control(self, control, control_type, indices=None, normalized=False):
+    def deploy_control(self, control, control_type):
         # We intercept the gripper control and replace it with the current joint position if we're freezing our gripper
         for arm in self.arm_names:
             if self._ag_freeze_gripper[arm]:
@@ -335,7 +335,7 @@ class ManipulationRobot(BaseRobot):
                     else 0.0
                 )
 
-        super().deploy_control(control=control, control_type=control_type, indices=indices, normalized=normalized)
+        super().deploy_control(control=control, control_type=control_type)
 
         # Then run assisted grasping
         if self.grasping_mode != "physical" and not self._disable_grasp_handling:
@@ -382,8 +382,9 @@ class ManipulationRobot(BaseRobot):
         # In addition to super method, add in EEF states
         fcns = super().get_control_dict()
 
-        for arm in self.arm_names:
-            self._add_arm_control_dict(fcns=fcns, arm=arm)
+        # TODO: Implement these also with the view.
+        # for arm in self.arm_names:
+        #     self._add_arm_control_dict(fcns=fcns, arm=arm)
 
         return fcns
 

--- a/omnigibson/robots/manipulation_robot.py
+++ b/omnigibson/robots/manipulation_robot.py
@@ -304,7 +304,7 @@ class ManipulationRobot(BaseRobot):
 
             # Translate that to robot contact data
             robot_contact_links = {}
-            for con_data in contact_data:
+            for con_data in raw_contact_data:
                 other_contact, link_contact = con_data
                 if other_contact not in robot_contact_links:
                     robot_contact_links[other_contact] = set()

--- a/omnigibson/robots/manipulation_robot.py
+++ b/omnigibson/robots/manipulation_robot.py
@@ -444,8 +444,8 @@ class ManipulationRobot(BaseRobot):
         dic = super()._get_proprioception_dict()
 
         # Loop over all arms to grab proprio info
-        joint_positions = self.get_joint_positions(normalized=False)
-        joint_velocities = self.get_joint_velocities(normalized=False)
+        joint_positions = ControllableObjectViewAPI.get_joint_positions(self.articulation_root_path)
+        joint_velocities = ControllableObjectViewAPI.get_joint_velocities(self.articulation_root_path)
         for arm in self.arm_names:
             # Add arm info
             dic["arm_{}_qpos".format(arm)] = joint_positions[self.arm_control_idx[arm]]
@@ -454,10 +454,11 @@ class ManipulationRobot(BaseRobot):
             dic["arm_{}_qvel".format(arm)] = joint_velocities[self.arm_control_idx[arm]]
 
             # Add eef and grasping info
-            dic["eef_{}_pos_global".format(arm)] = self.get_eef_position(arm)
-            dic["eef_{}_quat_global".format(arm)] = self.get_eef_orientation(arm)
-            dic["eef_{}_pos".format(arm)] = self.get_relative_eef_position(arm)
-            dic["eef_{}_quat".format(arm)] = self.get_relative_eef_orientation(arm)
+            # TODO: Should we include this? Seems hacky.
+            # dic["eef_{}_pos_global".format(arm)] = self.get_eef_position(arm)
+            # dic["eef_{}_quat_global".format(arm)] = self.get_eef_orientation(arm)
+            dic["eef_{}_pos".format(arm)], dic["eef_{}_quat".format(arm)] = (
+                ControllableObjectViewAPI.get_link_relative_position_orientation(self.eef_link_names[arm]))
             dic["grasp_{}".format(arm)] = np.array([self.is_grasping(arm)])
             dic["gripper_{}_qpos".format(arm)] = joint_positions[self.gripper_control_idx[arm]]
             dic["gripper_{}_qvel".format(arm)] = joint_velocities[self.gripper_control_idx[arm]]

--- a/omnigibson/robots/manipulation_robot.py
+++ b/omnigibson/robots/manipulation_robot.py
@@ -289,7 +289,7 @@ class ManipulationRobot(BaseRobot):
 
             # Get the interesting-columns from the impulse matrix
             interesting_impulse_columns = impulses[:, interesting_columns]
-            interesting_row_idxes = np.nonzero(np.any(interesting_impulse_columns > 0), axis=1)[0]
+            interesting_row_idxes = np.nonzero(np.any(interesting_impulse_columns > 0, axis=1))[0]
             interesting_row_paths = [GripperRigidContactAPI.get_row_idx_prim_path(i) for i in interesting_row_idxes]
 
             # Get the full interesting section of the impulse matrix

--- a/omnigibson/robots/manipulation_robot.py
+++ b/omnigibson/robots/manipulation_robot.py
@@ -458,7 +458,8 @@ class ManipulationRobot(BaseRobot):
             # dic["eef_{}_pos_global".format(arm)] = self.get_eef_position(arm)
             # dic["eef_{}_quat_global".format(arm)] = self.get_eef_orientation(arm)
             dic["eef_{}_pos".format(arm)], dic["eef_{}_quat".format(arm)] = (
-                ControllableObjectViewAPI.get_link_relative_position_orientation(self.eef_link_names[arm]))
+                ControllableObjectViewAPI.get_link_relative_position_orientation(self.eef_link_names[arm])
+            )
             dic["grasp_{}".format(arm)] = np.array([self.is_grasping(arm)])
             dic["gripper_{}_qpos".format(arm)] = joint_positions[self.gripper_control_idx[arm]]
             dic["gripper_{}_qvel".format(arm)] = joint_velocities[self.gripper_control_idx[arm]]

--- a/omnigibson/robots/manipulation_robot.py
+++ b/omnigibson/robots/manipulation_robot.py
@@ -430,14 +430,15 @@ class ManipulationRobot(BaseRobot):
         fcns[f"eef_{arm}_ang_vel_relative"] = lambda: ControllableObjectViewAPI.get_link_relative_angular_velocity(
             self.articulation_root_path, self.eef_link_names[arm]
         )
+        # TODO: This is currently disabled because it is NOT implemented with ControllableObjectViewAPI. Fix that.
         # -n_joints because there may be an additional 6 entries at the beginning of the array, if this robot does
         # not have a fixed base (i.e.: the 6DOF --> "floating" joint)
         # see self.get_relative_jacobian() for more info
-        eef_link_idx = self._articulation_view.get_body_index(self.eef_links[arm].body_name)
+        # eef_link_idx = self._articulation_view.get_body_index(self.eef_links[arm].body_name)
         # TODO: Replace this with a ControllableObjectViewAPI call too.
-        fcns[f"eef_{arm}_jacobian_relative"] = lambda: self.get_relative_jacobian(clone=False)[
-            eef_link_idx, :, -self.n_joints :
-        ]
+        # fcns[f"eef_{arm}_jacobian_relative"] = lambda: self.get_relative_jacobian(clone=False)[
+        #     eef_link_idx, :, -self.n_joints :
+        # ]
 
     def _get_proprioception_dict(self):
         dic = super()._get_proprioception_dict()

--- a/omnigibson/robots/robot_base.py
+++ b/omnigibson/robots/robot_base.py
@@ -162,8 +162,22 @@ class BaseRobot(USDObject, ControllableObject, GymObservable):
         # Run super first
         prim = super()._load()
 
-        # Also import dummy object if this robot is not fixed base
-        if self._use_dummy:
+        # Also import dummy object if this robot is not fixed base AND it has a controller that
+        # requires generalized gravity forces. We incur a relatively heavy cost at every step if we
+        # have to move the dummy. So we only do this if we absolutely need to.
+        needs_dummy = False
+        if not self.fixed_base:
+            # TODO: Make this work after controllers get updated post-load.
+            # Check if we have any operational space controllers or joint controllers with use_impedances on.
+            for cfg in self._controller_config.values():
+                if cfg["controller_type"] == "OperationalSpaceController":
+                    needs_dummy = True
+                    break
+                if cfg["controller_type"] == "JointController" and cfg.get("use_impedances", False):
+                    needs_dummy = True
+                    break
+
+        if needs_dummy:
             dummy_path = f"{self._prim_path}_dummy"
             dummy_prim = add_asset_to_stage(asset_path=self._dummy_usd_path, prim_path=dummy_path)
             self._dummy = BaseObject(
@@ -287,7 +301,7 @@ class BaseRobot(USDObject, ControllableObject, GymObservable):
         # This is done prior to any state getter calls, since setting kinematic state results in physx backend
         # having to re-fetch tensorized state.
         # We do this so we have more optimal runtime performance
-        if self._use_dummy:
+        if self._dummy is not None:
             self._dummy.set_joint_positions(self.get_joint_positions())
             self._dummy.set_joint_velocities(self.get_joint_velocities())
             self._dummy.set_position_orientation(*self.get_position_orientation())
@@ -503,9 +517,12 @@ class BaseRobot(USDObject, ControllableObject, GymObservable):
 
     def get_generalized_gravity_forces(self, clone=True):
         # Override method based on whether we're using a dummy or not
+        assert (
+            self._dummy is not None or not self.fixed_base
+        ), "Cannot compute generalized gravity forces for fixed base robot without a dummy!"
         return (
             self._dummy.get_generalized_gravity_forces(clone=clone)
-            if self._use_dummy
+            if not self.fixed_base
             else super().get_generalized_gravity_forces(clone=clone)
         )
 
@@ -635,15 +652,6 @@ class BaseRobot(USDObject, ControllableObject, GymObservable):
             str: file path to the robot urdf file.
         """
         raise NotImplementedError
-
-    @property
-    def _use_dummy(self):
-        """
-        Returns:
-            bool: Whether the robot dummy should be loaded and used for some computations, e.g., gravity compensation
-        """
-        # By default, only load if robot is not fixed base
-        return not self.fixed_base
 
     @classproperty
     def _do_not_register_classes(cls):

--- a/omnigibson/robots/robot_base.py
+++ b/omnigibson/robots/robot_base.py
@@ -168,14 +168,17 @@ class BaseRobot(USDObject, ControllableObject, GymObservable):
         needs_dummy = False
         if not self.fixed_base:
             # TODO: Make this work after controllers get updated post-load.
+            # TODO: Make this work - for now this feature is disabled because we can't check the config
+            # at this time.
             # Check if we have any operational space controllers or joint controllers with use_impedances on.
-            for cfg in self._controller_config.values():
-                if cfg["controller_type"] == "OperationalSpaceController":
-                    needs_dummy = True
-                    break
-                if cfg["controller_type"] == "JointController" and cfg.get("use_impedances", False):
-                    needs_dummy = True
-                    break
+            # for cfg in self._controller_config.values():
+            #     if cfg["controller_type"] == "OperationalSpaceController":
+            #         needs_dummy = True
+            #         break
+            #     if cfg["controller_type"] == "JointController" and cfg.get("use_impedances", False):
+            #         needs_dummy = True
+            #         break
+            pass
 
         if needs_dummy:
             dummy_path = f"{self._prim_path}_dummy"

--- a/omnigibson/robots/tiago.py
+++ b/omnigibson/robots/tiago.py
@@ -9,7 +9,7 @@ from omnigibson.robots.active_camera_robot import ActiveCameraRobot
 from omnigibson.robots.manipulation_robot import GraspingPoint, ManipulationRobot
 from omnigibson.robots.locomotion_robot import LocomotionRobot
 from omnigibson.utils.python_utils import assert_valid_key
-from omnigibson.utils.usd_utils import JointType
+from omnigibson.utils.usd_utils import ControllableObjectViewAPI, JointType
 
 # Create settings for this module
 m = create_module_macros(module_path=__file__)
@@ -332,8 +332,8 @@ class Tiago(ManipulationRobot, LocomotionRobot, ActiveCameraRobot):
         dic = super()._get_proprioception_dict()
 
         # Add trunk info
-        joint_positions = self.get_joint_positions(normalized=False)
-        joint_velocities = self.get_joint_velocities(normalized=False)
+        joint_positions = ControllableObjectViewAPI.get_joint_positions(self.articulation_root_path)
+        joint_velocities = ControllableObjectViewAPI.get_joint_velocities(self.articulation_root_path)
         dic["trunk_qpos"] = joint_positions[self.trunk_control_idx]
         dic["trunk_qvel"] = joint_velocities[self.trunk_control_idx]
 

--- a/omnigibson/robots/two_wheel_robot.py
+++ b/omnigibson/robots/two_wheel_robot.py
@@ -68,7 +68,9 @@ class TwoWheelRobot(LocomotionRobot):
         dic = super()._get_proprioception_dict()
 
         # Grab wheel joint velocity info
-        l_vel, r_vel = ControllableObjectViewAPI.get_joint_velocities(self.articulation_root_path)[self.base_control_idx]
+        l_vel, r_vel = ControllableObjectViewAPI.get_joint_velocities(self.articulation_root_path)[
+            self.base_control_idx
+        ]
 
         # Compute linear and angular velocities
         lin_vel = (l_vel + r_vel) / 2.0 * self.wheel_radius

--- a/omnigibson/robots/two_wheel_robot.py
+++ b/omnigibson/robots/two_wheel_robot.py
@@ -5,6 +5,7 @@ import numpy as np
 from omnigibson.controllers import DifferentialDriveController
 from omnigibson.robots.locomotion_robot import LocomotionRobot
 from omnigibson.utils.python_utils import classproperty
+from omnigibson.utils.usd_utils import ControllableObjectViewAPI
 
 
 class TwoWheelRobot(LocomotionRobot):
@@ -67,9 +68,7 @@ class TwoWheelRobot(LocomotionRobot):
         dic = super()._get_proprioception_dict()
 
         # Grab wheel joint velocity info
-        joints = list(self._joints.values())
-        wheel_joints = [joints[idx] for idx in self.base_control_idx]
-        l_vel, r_vel = [jnt.get_state()[1] for jnt in wheel_joints]
+        l_vel, r_vel = ControllableObjectViewAPI.get_joint_velocities(self.articulation_root_path)[self.base_control_idx]
 
         # Compute linear and angular velocities
         lin_vel = (l_vel + r_vel) / 2.0 * self.wheel_radius

--- a/omnigibson/simulator.py
+++ b/omnigibson/simulator.py
@@ -1394,7 +1394,7 @@ def launch_simulator(*args, **kwargs):
                 self._on_contact
             )
             self._physics_step_callback = self._physics_context._physx_interface.subscribe_physics_step_events(
-                self._on_physics_step
+                lambda: self._on_physics_step()
             )
             self._simulation_event_callback = (
                 self._physx_interface.get_simulation_event_stream_v2().create_subscription_to_pop(

--- a/omnigibson/simulator.py
+++ b/omnigibson/simulator.py
@@ -30,6 +30,7 @@ from omnigibson.utils.usd_utils import (
     clear as clear_uu,
     FlatcacheAPI,
     RigidContactAPI,
+    GripperRigidContactAPI,
     PoseAPI,
 )
 from omnigibson.utils.ui_utils import (
@@ -658,6 +659,7 @@ def launch_simulator(*args, **kwargs):
 
             # Finally update any unified views
             RigidContactAPI.initialize_view()
+            GripperRigidContactAPI.initialize_view()
             ControllableObjectViewAPI.initialize_view()
 
         def _non_physics_step(self):
@@ -730,6 +732,7 @@ def launch_simulator(*args, **kwargs):
             """
             # Clear the bounding box and contact caches so that they get updated during the next time they're called
             RigidContactAPI.clear()
+            GripperRigidContactAPI.clear()
             ControllableObjectViewAPI.clear()
 
         def play(self):

--- a/omnigibson/simulator.py
+++ b/omnigibson/simulator.py
@@ -1394,7 +1394,7 @@ def launch_simulator(*args, **kwargs):
                 self._on_contact
             )
             self._physics_step_callback = self._physics_context._physx_interface.subscribe_physics_step_events(
-                lambda: self._on_physics_step()
+                lambda _: self._on_physics_step()
             )
             self._simulation_event_callback = (
                 self._physx_interface.get_simulation_event_stream_v2().create_subscription_to_pop(

--- a/omnigibson/utils/usd_utils.py
+++ b/omnigibson/utils/usd_utils.py
@@ -605,7 +605,7 @@ class ControllableObjectViewAPI:
         ), "Controllable objects must have a link named base_link as the root link."
 
         # Get their corresponding prim paths
-        expected_regular_prim_paths = {obj.root_link.articulation_root_path for obj in controllable_objects}
+        expected_regular_prim_paths = {obj.articulation_root_path for obj in controllable_objects}
         expected_dummy_prim_paths = {
             obj._dummy.articulation_root_path
             for obj in controllable_objects

--- a/omnigibson/utils/usd_utils.py
+++ b/omnigibson/utils/usd_utils.py
@@ -9,7 +9,6 @@ import trimesh
 
 import omnigibson as og
 from omnigibson.macros import gm
-from omnigibson.objects.controllable_object import ControllableObject
 from omnigibson.utils.constants import JointType, PRIMITIVE_MESH_TYPES, PrimType
 from omnigibson.utils.python_utils import assert_valid_key
 from omnigibson.utils.ui_utils import suppress_omni_log
@@ -594,7 +593,9 @@ class ControllableObjectViewAPI:
 
     @classmethod
     def initialize_view(cls):
-        # First, get all of the controllable objects in the scene
+        # First, get all of the controllable objects in the scene (avoiding circular import)
+        from omnigibson.objects.controllable_object import ControllableObject
+
         controllable_objects = [obj for obj in og.sim.scene.objects if isinstance(obj, ControllableObject)]
 
         # Get their corresponding prim paths

--- a/omnigibson/utils/usd_utils.py
+++ b/omnigibson/utils/usd_utils.py
@@ -603,7 +603,7 @@ class ControllableObjectViewAPI:
 
         # Create the actual articulation view
         cls._VIEW = og.sim.physics_sim_view.create_articulation_view("/World/controllable_*/*")
-        view_prim_paths = cls._VIEW.metadata.prim_paths
+        view_prim_paths = cls._VIEW.prim_paths
         assert (
             set(view_prim_paths) == expected_prim_paths
         ), f"ControllableObjectViewAPI expected prim paths {expected_prim_paths} but got {view_prim_paths}"


### PR DESCRIPTION
Currently, adding more robots into the simulation significantly increases the amount of time spent in the controller step. This aims to alleviate that by unifying articulationview reads/writes.