### PR TITLE
Fix geodesic_reward==None bug

### DIFF
--- a/omnigibson/tasks/point_navigation_task.py
+++ b/omnigibson/tasks/point_navigation_task.py
@@ -260,17 +260,20 @@ class PointNavigationTask(BaseTask):
         log.info("Sampled goal position: {}".format(goal_pos))
         return initial_pos, initial_quat, goal_pos
 
-    def _get_geodesic_potential(self, env):
+    def _get_geodesic_potential(self, env, no_path_reward=-1.0):
         """
         Get potential based on geodesic distance
 
         Args:
             env: environment instance
+            no_path_reward (float): Reward to return if no path is found to the goal position
 
         Returns:
             float: geodesic distance to the target position
         """
         _, geodesic_dist = self.get_shortest_path_to_goal(env=env)
+        if geodesic_dist is None:
+            return no_path_reward
         return geodesic_dist
 
     def _get_l2_potential(self, env):
@@ -285,12 +288,13 @@ class PointNavigationTask(BaseTask):
         """
         return T.l2_distance(env.robots[self._robot_idn].states[Pose].get_value()[0][:2], self._goal_pos[:2])
 
-    def get_potential(self, env):
+    def get_potential(self, env, no_path_reward=-1.0):
         """
         Compute task-specific potential: distance to the goal
 
         Args:
             env (Environment): Environment instance
+            no_path_reward (float): Reward to return if no path is found to the goal position
 
         Returns:
             float: Computed potential
@@ -298,7 +302,7 @@ class PointNavigationTask(BaseTask):
         if self._reward_type == "l2":
             reward = self._get_l2_potential(env)
         elif self._reward_type == "geodesic":
-            reward = self._get_geodesic_potential(env)
+            reward = self._get_geodesic_potential(env, no_path_reward=no_path_reward)
         else:
             raise ValueError(f"Invalid reward type! {self._reward_type}")
 


### PR DESCRIPTION
Original issue: [https://github.com/StanfordVL/OmniGibson/issues/715](https://github.com/StanfordVL/OmniGibson/issues/715)

The problem here is our `get_shortest_path` function returns `None` when no path is found but this is directly fed into a numerical computation for rewards: `(self._potential - new_potential)*self._r_potential`. 

The proposed fix here is to pass in a float `no_path_reward` arg. I'm not super familiar with this RL infra though, would appreciate input on where this `no_path_reward` should be exposed to the users. 