### PR TITLE
Clean up launch / clear interface and fix some bugs

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -55,6 +55,7 @@ while true; do
     esac
 done
 
+docker pull stanfordvl/omnigibson:latest
 DOCKER_DISPLAY=""
 OMNIGIBSON_HEADLESS=1
 if [ "$GUI" = true ] ; then
@@ -65,10 +66,8 @@ fi
 docker run \
     --gpus all \
     --privileged \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e DISPLAY=${DOCKER_DISPLAY} \
     -e OMNIGIBSON_HEADLESS=${OMNIGIBSON_HEADLESS} \
-    -v /scr/OmniGibson:/omnigibson-src:rw \
     -v $DATA_PATH/datasets:/data \
     -v $DATA_PATH/isaac-sim/cache/kit:/isaac-sim/kit/cache/Kit:rw \
     -v $DATA_PATH/isaac-sim/cache/ov:/root/.cache/ov:rw \

--- a/omnigibson/envs/env_base.py
+++ b/omnigibson/envs/env_base.py
@@ -10,7 +10,6 @@ from omnigibson.robots import REGISTERED_ROBOTS
 from omnigibson.scene_graphs.graph_builder import SceneGraphBuilder
 from omnigibson.scenes import REGISTERED_SCENES
 from omnigibson.sensors import VisionSensor, create_sensor
-from omnigibson.simulator import launch_simulator
 from omnigibson.tasks import REGISTERED_TASKS
 from omnigibson.utils.config_utils import parse_config
 from omnigibson.utils.gym_utils import (
@@ -81,14 +80,22 @@ class Environment(gym.Env, GymObservable, Recreatable):
         viewer_height = self.render_config["viewer_height"]
         # If the sim is launched, check that the parameters match
         if og.sim is not None:
-            assert og.sim.initial_physics_dt == physics_frequency
-            assert og.sim.initial_rendering_dt == rendering_frequency
-            assert og.sim.device == self.device
-            assert og.sim.viewer_width == viewer_width
-            assert og.sim.viewer_height == viewer_height
-        # Otherwise, launch Isaac Sim
+            assert (
+                og.sim.initial_physics_dt == physics_frequency
+            ), f"Physics frequency mismatch! Expected {physics_frequency}, got {og.sim.initial_physics_dt}"
+            assert (
+                og.sim.initial_rendering_dt == rendering_frequency
+            ), f"Rendering frequency mismatch! Expected {rendering_frequency}, got {og.sim.initial_rendering_dt}"
+            assert og.sim.device == self.device, f"Device mismatch! Expected {self.device}, got {og.sim.device}"
+            assert (
+                og.sim.viewer_width == viewer_width
+            ), f"Viewer width mismatch! Expected {viewer_width}, got {og.sim.viewer_width}"
+            assert (
+                og.sim.viewer_height == viewer_height
+            ), f"Viewer height mismatch! Expected {viewer_height}, got {og.sim.viewer_height}"
+        # Otherwise, launch a simulator instance
         else:
-            launch_simulator(
+            og.launch(
                 physics_dt=physics_frequency,
                 rendering_dt=rendering_frequency,
                 device=self.device,

--- a/omnigibson/simulator.py
+++ b/omnigibson/simulator.py
@@ -224,7 +224,7 @@ def _launch_app():
     return app
 
 
-def launch_simulator(*args, **kwargs):
+def _launch_simulator(*args, **kwargs):
     if not og.app:
         og.app = _launch_app()
 
@@ -243,8 +243,6 @@ def launch_simulator(*args, **kwargs):
                 current application and not only rendering a frame to the viewports/ cameras. So UI elements of
                 Isaac Sim will be refreshed with this dt as well if running non-headless. If None, will use default
                 value 1 / gm.DEFAULT_RENDERING_FREQ
-            stage_units_in_meters (float): The metric units of assets. This will affect gravity value..etc.
-                Defaults to 0.01.
             viewer_width (int): width of the camera image, in pixels
             viewer_height (int): height of the camera image, in pixels
             device (None or str): specifies the device to be used if running on the gpu with torch backend
@@ -255,7 +253,6 @@ def launch_simulator(*args, **kwargs):
             gravity=9.81,
             physics_dt=None,
             rendering_dt=None,
-            stage_units_in_meters=1.0,
             viewer_width=gm.DEFAULT_VIEWER_WIDTH,
             viewer_height=gm.DEFAULT_VIEWER_HEIGHT,
             device=None,
@@ -284,7 +281,6 @@ def launch_simulator(*args, **kwargs):
             super().__init__(
                 physics_dt=1.0 / gm.DEFAULT_PHYSICS_FREQ if physics_dt is None else physics_dt,
                 rendering_dt=1.0 / gm.DEFAULT_RENDERING_FREQ if rendering_dt is None else rendering_dt,
-                stage_units_in_meters=stage_units_in_meters,
                 device=device,
             )
 
@@ -1426,6 +1422,43 @@ def launch_simulator(*args, **kwargs):
                 return jsons
 
             return None
+
+        def _partial_clear(self):
+            """Partial clear clearing all components owned by the Simulator. Rest is completed in og.clear."""
+            # Stop the physics
+            self.stop()
+
+            # Clear all scenes
+            for scene in self.scenes:
+                scene.clear()
+
+            # Remove the skybox, floor plane and viewer camera
+            if self._skybox is not None:
+                self._skybox.remove()
+
+            if self._floor_plane is not None:
+                self._floor_plane.remove()
+
+            if self._viewer_camera is not None:
+                self._viewer_camera.remove()
+
+            if self._camera_mover is not None:
+                self._camera_mover.clear()
+
+            # Clear the vision sensor cache
+            VisionSensor.clear()
+
+            # Clear all global update states
+            for state in self.object_state_types_requiring_update:
+                if issubclass(state, GlobalUpdateStateMixin):
+                    state.global_initialize()
+
+            # Clear all materials
+            MaterialPrim.clear()
+
+            # Clear uniquely named items and other internal states
+            clear_python_utils()
+            clear_usd_utils()
 
         def close(self):
             """

--- a/tests/benchmark/benchmark_interactive_scene.py
+++ b/tests/benchmark/benchmark_interactive_scene.py
@@ -11,7 +11,6 @@ from omnigibson.macros import gm
 from omnigibson.objects import DatasetObject
 from omnigibson.robots.turtlebot import Turtlebot
 from omnigibson.scenes.interactive_traversable_scene import InteractiveTraversableScene
-from omnigibson.simulator import launch_simulator
 from omnigibson.utils.asset_utils import get_og_assets_version
 from omnigibson.utils.constants import PrimType
 
@@ -32,7 +31,7 @@ gm.DEFAULT_VIEWER_HEIGHT = 128
 
 
 # Launch the simulator
-launch_simulator(physics_dt=1 / 60.0, rendering_dt=1 / 60.0)
+og.launch(physics_dt=1 / 60.0, rendering_dt=1 / 60.0)
 
 
 def benchmark_scene(scene_name, non_rigid_simulation=False, import_robot=True):

--- a/tests/benchmark/benchmark_object_count.py
+++ b/tests/benchmark/benchmark_object_count.py
@@ -8,7 +8,7 @@ import time
 import matplotlib.pyplot as plt
 import numpy as np
 
-from omnigibson import app, launch_simulator
+from omnigibson import app, launch
 from omnigibson.objects.primitive_object import PrimitiveObject
 from omnigibson.scenes.scene_base import Scene
 from omnigibson.utils.asset_utils import get_og_assets_version
@@ -94,7 +94,7 @@ def benchmark_scene(sim):
 def main():
     assert MAX_NUM_OBJS <= 1000
 
-    sim = launch_simulator()
+    sim = launch()
     benchmark_scene(sim)
     app.close()
 


### PR DESCRIPTION
In the new clear paradigm, the simulator gets deleted and a new one launched, but we don't pay attention to keep the kwargs of the original simulator the same, which is a bug and caught by tests. This fixes that.

This should hopefully unbreak the env test. Also, we fix an accidentally merged change on the run_docker file.