### PR TITLE
Fix issue #754: Avoid circular reference between scene and object

### DIFF
--- a/omnigibson/prims/prim_base.py
+++ b/omnigibson/prims/prim_base.py
@@ -46,7 +46,7 @@ class BasePrim(Serializable, Recreatable, ABC):
         self._load_config = dict() if load_config is None else load_config
 
         # Other values that will be filled in at runtime
-        self._scene = None
+        self._scene_idx = None
         self._scene_assigned = False
         self._applied_visual_material = None
         self._loaded = False  # Whether this prim exists in the stage or not
@@ -97,8 +97,9 @@ class BasePrim(Serializable, Recreatable, ABC):
             not self._loaded
         ), f"Prim {self.name} at prim_path {self.prim_path} can only be loaded once! (It is already loaded)"
 
-        # Assign the scene first.
-        self._scene = scene
+        # Assign the scene index first.
+        if scene is not None:
+            self._scene_idx = scene.idx
         self._scene_assigned = True
 
         # Then check if the prim is already loaded
@@ -158,7 +159,11 @@ class BasePrim(Serializable, Recreatable, ABC):
             Scene or None: Scene object that this prim is loaded into
         """
         assert self._scene_assigned, "Scene has not been assigned to this prim yet!"
-        return self._scene
+
+        scene = None
+        if self._scene_idx is not None:
+            scene = og.sim.scenes[self._scene_idx]
+        return scene
 
     @property
     def state_size(self):


### PR DESCRIPTION
BasePrim object stores the scene index instead of the scene object. When query a scene from a BasePrim object, it fetches the corresponding scene stored in the Simulator attributes "scenes" list.