### PR TITLE
 Fix issue #754: Avoid circular reference between scene and object

### DIFF
--- a/omnigibson/prims/prim_base.py
+++ b/omnigibson/prims/prim_base.py
@@ -96,10 +96,10 @@ class BasePrim(Serializable, Recreatable, ABC):
         assert (
             not self._loaded
         ), f"Prim {self.name} at prim_path {self.prim_path} can only be loaded once! (It is already loaded)"
-        # assert scene is not None, "Scene should not be None for prim {self.name}!".format(self=self)
 
         # Assign the scene index first.
         self._scene_idx = scene_idx
+        self._scene_assigned = True
 
         # Then check if the prim is already loaded
         if lazy.omni.isaac.core.utils.prims.is_prim_path_valid(prim_path=self.prim_path):
@@ -157,7 +157,7 @@ class BasePrim(Serializable, Recreatable, ABC):
         Returns:
             Scene or None: Scene object that this prim is loaded into
         """
-        # assert self._scene_assigned, "Scene has not been assigned to this prim yet!"
+        assert self._scene_assigned, "Scene has not been assigned to this prim yet!"
 
         if self._scene_idx is None:
             return None
@@ -174,7 +174,6 @@ class BasePrim(Serializable, Recreatable, ABC):
         Returns:
             str: prim path in the stage.
         """
-        # assert self._scene_idx is not None, "Scene not set for system {self.name}!".format(self=self)
 
         return scene_relative_prim_path_to_absolute(self._scene_idx, self._relative_prim_path)
 

--- a/omnigibson/prims/prim_base.py
+++ b/omnigibson/prims/prim_base.py
@@ -46,7 +46,7 @@ class BasePrim(Serializable, Recreatable, ABC):
         self._load_config = dict() if load_config is None else load_config
 
         # Other values that will be filled in at runtime
-        self._scene = None
+        self._scene_idx = None
         self._scene_assigned = False
         self._applied_visual_material = None
         self._loaded = False  # Whether this prim exists in the stage or not
@@ -97,8 +97,9 @@ class BasePrim(Serializable, Recreatable, ABC):
             not self._loaded
         ), f"Prim {self.name} at prim_path {self.prim_path} can only be loaded once! (It is already loaded)"
 
-        # Assign the scene first.
-        self._scene = scene
+        # Assign the scene index first.
+        if scene is not None:
+            self._scene_idx = scene.idx
         self._scene_assigned = True
 
         # Then check if the prim is already loaded
@@ -158,7 +159,11 @@ class BasePrim(Serializable, Recreatable, ABC):
             Scene or None: Scene object that this prim is loaded into
         """
         assert self._scene_assigned, "Scene has not been assigned to this prim yet!"
-        return self._scene
+
+        scene = None
+        if self._scene_idx is not None:
+            scene = og.sim.scenes[self._scene_idx]
+        return scene
 
     @property
     def state_size(self):

--- a/omnigibson/prims/prim_base.py
+++ b/omnigibson/prims/prim_base.py
@@ -96,11 +96,12 @@ class BasePrim(Serializable, Recreatable, ABC):
         assert (
             not self._loaded
         ), f"Prim {self.name} at prim_path {self.prim_path} can only be loaded once! (It is already loaded)"
+        # assert scene is not None, "Scene should not be None for prim {self.name}!".format(self=self)
 
         # Assign the scene index first.
         if scene is not None:
             self._scene_idx = scene.idx
-        self._scene_assigned = True
+            self._scene_assigned = True
 
         # Then check if the prim is already loaded
         if lazy.omni.isaac.core.utils.prims.is_prim_path_valid(prim_path=self.prim_path):
@@ -158,7 +159,7 @@ class BasePrim(Serializable, Recreatable, ABC):
         Returns:
             Scene or None: Scene object that this prim is loaded into
         """
-        assert self._scene_assigned, "Scene has not been assigned to this prim yet!"
+        # assert self._scene_assigned, "Scene has not been assigned to this prim yet!"
 
         scene = None
         if self._scene_idx is not None:
@@ -176,7 +177,12 @@ class BasePrim(Serializable, Recreatable, ABC):
         Returns:
             str: prim path in the stage.
         """
-        return scene_relative_prim_path_to_absolute(self.scene, self._relative_prim_path)
+        # assert self._scene_idx is not None, "Scene not set for system {self.name}!".format(self=self)
+
+        scene = None
+        if self._scene_idx is not None:
+            scene = og.sim.scenes[self._scene_idx]
+        return scene_relative_prim_path_to_absolute(scene, self._relative_prim_path)
 
     @property
     def name(self):

--- a/omnigibson/prims/prim_base.py
+++ b/omnigibson/prims/prim_base.py
@@ -85,7 +85,7 @@ class BasePrim(Serializable, Recreatable, ABC):
         # dump_state asserts that the prim is initialized for some prims).
         self._state_size = len(self.dump_state(serialized=True))
 
-    def load(self, scene):
+    def load(self, scene_idx):
         """
         Load this prim into omniverse, and return loaded prim reference.
 
@@ -99,9 +99,7 @@ class BasePrim(Serializable, Recreatable, ABC):
         # assert scene is not None, "Scene should not be None for prim {self.name}!".format(self=self)
 
         # Assign the scene index first.
-        if scene is not None:
-            self._scene_idx = scene.idx
-            self._scene_assigned = True
+        self._scene_idx = scene_idx
 
         # Then check if the prim is already loaded
         if lazy.omni.isaac.core.utils.prims.is_prim_path_valid(prim_path=self.prim_path):
@@ -161,10 +159,9 @@ class BasePrim(Serializable, Recreatable, ABC):
         """
         # assert self._scene_assigned, "Scene has not been assigned to this prim yet!"
 
-        scene = None
-        if self._scene_idx is not None:
-            scene = og.sim.scenes[self._scene_idx]
-        return scene
+        if self._scene_idx is None:
+            return None
+        return og.sim.scenes[self._scene_idx]
 
     @property
     def state_size(self):
@@ -179,10 +176,7 @@ class BasePrim(Serializable, Recreatable, ABC):
         """
         # assert self._scene_idx is not None, "Scene not set for system {self.name}!".format(self=self)
 
-        scene = None
-        if self._scene_idx is not None:
-            scene = og.sim.scenes[self._scene_idx]
-        return scene_relative_prim_path_to_absolute(scene, self._relative_prim_path)
+        return scene_relative_prim_path_to_absolute(self._scene_idx, self._relative_prim_path)
 
     @property
     def name(self):

--- a/omnigibson/systems/micro_particle_system.py
+++ b/omnigibson/systems/micro_particle_system.py
@@ -1436,7 +1436,9 @@ class FluidSystem(MicroPhysicalParticleSystem):
 
     def _create_particle_prototypes(self):
         # Simulate particles with simple spheres
-        prototype_prim_path = f"{scene_relative_prim_path_to_absolute(self._scene.idx, self.relative_prim_path)}/prototype0"
+        prototype_prim_path = (
+            f"{scene_relative_prim_path_to_absolute(self._scene.idx, self.relative_prim_path)}/prototype0"
+        )
         prototype = lazy.pxr.UsdGeom.Sphere.Define(og.sim.stage, prototype_prim_path)
         prototype.CreateRadiusAttr().Set(self.particle_radius)
         relative_prototype_prim_path = absolute_prim_path_to_scene_relative(self._scene, prototype_prim_path)

--- a/omnigibson/systems/micro_particle_system.py
+++ b/omnigibson/systems/micro_particle_system.py
@@ -1436,7 +1436,7 @@ class FluidSystem(MicroPhysicalParticleSystem):
 
     def _create_particle_prototypes(self):
         # Simulate particles with simple spheres
-        prototype_prim_path = f"{scene_relative_prim_path_to_absolute(self._scene, self.relative_prim_path)}/prototype0"
+        prototype_prim_path = f"{scene_relative_prim_path_to_absolute(self._scene.idx, self.relative_prim_path)}/prototype0"
         prototype = lazy.pxr.UsdGeom.Sphere.Define(og.sim.stage, prototype_prim_path)
         prototype.CreateRadiusAttr().Set(self.particle_radius)
         relative_prototype_prim_path = absolute_prim_path_to_scene_relative(self._scene, prototype_prim_path)

--- a/omnigibson/systems/micro_particle_system.py
+++ b/omnigibson/systems/micro_particle_system.py
@@ -746,14 +746,14 @@ class MicroPhysicalParticleSystem(MicroParticleSystem, PhysicalParticleSystem):
             for instancer in self.particle_instancers.values():
                 instancer.particle_prototype_ids = np.zeros(instancer.n_particles, dtype=np.int32)
 
-    def initialize(self, scene):
-        self._scene = scene
+    def initialize(self, scene_idx):
+        self._scene_idx = scene_idx
 
         # Create prototype before running super!
         self.particle_prototypes = self._create_particle_prototypes()
 
         # Run super
-        super().initialize(scene)
+        super().initialize(scene_idx)
 
         # Potentially set system prim's max velocity value
         if m.MICRO_PARTICLE_SYSTEM_MAX_VELOCITY is not None:
@@ -1437,13 +1437,13 @@ class FluidSystem(MicroPhysicalParticleSystem):
     def _create_particle_prototypes(self):
         # Simulate particles with simple spheres
         prototype_prim_path = (
-            f"{scene_relative_prim_path_to_absolute(self._scene.idx, self.relative_prim_path)}/prototype0"
+            f"{scene_relative_prim_path_to_absolute(self._scene_idx, self.relative_prim_path)}/prototype0"
         )
         prototype = lazy.pxr.UsdGeom.Sphere.Define(og.sim.stage, prototype_prim_path)
         prototype.CreateRadiusAttr().Set(self.particle_radius)
-        relative_prototype_prim_path = absolute_prim_path_to_scene_relative(self._scene, prototype_prim_path)
+        relative_prototype_prim_path = absolute_prim_path_to_scene_relative(self._scene_idx, prototype_prim_path)
         prototype = VisualGeomPrim(relative_prim_path=relative_prototype_prim_path, name=f"{self.name}_prototype0")
-        prototype.load(self._scene)
+        prototype.load(self._scene_idx)
         prototype.visible = False
         lazy.omni.isaac.core.utils.semantics.add_update_semantics(
             prim=prototype.prim,
@@ -1543,7 +1543,7 @@ class GranularSystem(MicroPhysicalParticleSystem):
     def _create_particle_prototypes(self):
         # Load the particle template
         particle_template = self._create_particle_template()
-        particle_template.load(self._scene)
+        particle_template.load(self._scene_idx)
         og.sim.post_import_object(particle_template)
         self._particle_template = particle_template
         # Make sure there is no ambiguity about which mesh to use as the particle from this template
@@ -1563,9 +1563,9 @@ class GranularSystem(MicroPhysicalParticleSystem):
         lazy.omni.kit.commands.execute("CopyPrim", path_from=visual_geom.prim_path, path_to=prototype_path)
 
         # Wrap it with VisualGeomPrim with the correct scale
-        relative_prototype_path = absolute_prim_path_to_scene_relative(self._scene, prototype_path)
+        relative_prototype_path = absolute_prim_path_to_scene_relative(self._scene_idx, prototype_path)
         prototype = VisualGeomPrim(relative_prim_path=relative_prototype_path, name=prototype_path)
-        prototype.load(self._scene)
+        prototype.load(self._scene_idx)
         prototype.scale *= self.max_scale
         prototype.visible = False
         lazy.omni.isaac.core.utils.semantics.add_update_semantics(

--- a/omnigibson/systems/system_base.py
+++ b/omnigibson/systems/system_base.py
@@ -145,7 +145,7 @@ class BaseSystem(Serializable):
             Scene index or None: Index of scene object that this prim is loaded into
         """
         assert self.initialized, f"System {self.name} has not been initialized yet!"
-        
+
         if self._scene_idx is None:
             return None
         return og.sim.scenes[self._scene_idx]

--- a/omnigibson/systems/system_base.py
+++ b/omnigibson/systems/system_base.py
@@ -55,7 +55,7 @@ class BaseSystem(Serializable):
         self._uuid = get_uuid(self.name)
         UUID_TO_SYSTEM_NAME[self._uuid] = self.name
 
-        self._scene = None
+        self._scene_idx = None
 
     @property
     def name(self):
@@ -72,8 +72,12 @@ class BaseSystem(Serializable):
         Returns:
             str: Path to this system's prim in the scene stage
         """
-        assert self._scene is not None, "Scene not set for system {self.name}!".format(self=self)
-        return scene_relative_prim_path_to_absolute(self._scene, self.relative_prim_path)
+        # assert self._scene_idx is not None, "Scene not set for system {self.name}!".format(self=self)
+
+        scene = None
+        if self._scene_idx is not None:
+            scene = og.sim.scenes[self._scene_idx]
+        return scene_relative_prim_path_to_absolute(scene, self.relative_prim_path)
 
     @property
     def relative_prim_path(self):
@@ -122,7 +126,10 @@ class BaseSystem(Serializable):
         Initializes this system
         """
         assert not self.initialized, f"Already initialized system {self.name}!"
-        self._scene = scene
+        # assert scene is not None, "Scene should not be None for system {self.name}!".format(self=self)
+
+        if scene is not None:
+            self._scene_idx = scene.idx
         self.initialized = True
 
         og.sim.stage.DefinePrim(self.prim_path, "Scope")
@@ -140,8 +147,12 @@ class BaseSystem(Serializable):
         Returns:
             Scene or None: Scene object that this prim is loaded into
         """
-        assert self.initialized, f"System {self.name} has not been initialized yet!"
-        return self._scene
+        # assert self.initialized, f"System {self.name} has not been initialized yet!"
+
+        scene = None
+        if self._scene_idx is not None:
+            scene = og.sim.scenes[self._scene_idx]
+        return scene
 
     def update(self):
         """
@@ -209,7 +220,7 @@ class BaseSystem(Serializable):
             self.scene.transition_rule_api.prune_active_rules()
 
         self.initialized = False
-        self._scene = None
+        self._scene_idx = None
 
     def reset(self):
         """

--- a/omnigibson/systems/system_base.py
+++ b/omnigibson/systems/system_base.py
@@ -72,7 +72,6 @@ class BaseSystem(Serializable):
         Returns:
             str: Path to this system's prim in the scene stage
         """
-        # assert self._scene_idx is not None, "Scene not set for system {self.name}!".format(self=self)
 
         return scene_relative_prim_path_to_absolute(self._scene_idx, self.relative_prim_path)
 
@@ -123,7 +122,6 @@ class BaseSystem(Serializable):
         Initializes this system
         """
         assert not self.initialized, f"Already initialized system {self.name}!"
-        # assert scene is not None, "Scene should not be None for system {self.name}!".format(self=self)
 
         self._scene_idx = scene_idx
         self.initialized = True

--- a/omnigibson/transition_rules.py
+++ b/omnigibson/transition_rules.py
@@ -66,10 +66,8 @@ class TransitionRuleAPI:
     Containing methods to check and execute arbitrary discrete state transitions within the simulator
     """
 
-    def __init__(self, scene):
-        self._scene_idx = None
-        if scene is not None:
-            self._scene_idx = scene.idx
+    def __init__(self, scene_idx):
+        self._scene_idx = scene_idx
 
         # Set of active rules
         self.active_rules = set()
@@ -79,7 +77,7 @@ class TransitionRuleAPI:
         # "callback": None or function to execute when the object is initialized
         self.obj_init_info = dict()
 
-        self.all_rules = set([rule(scene) for rule in RULES_REGISTRY.objects])
+        self.all_rules = set([rule(self.scene) for rule in RULES_REGISTRY.objects])
 
     @property
     def scene(self):
@@ -88,10 +86,9 @@ class TransitionRuleAPI:
             Scene or None: Scene object that this transition rule is loaded into
         """
 
-        scene = None
-        if self._scene_idx is not None:
-            scene = og.sim.scenes[self._scene_idx]
-        return scene
+        if self._scene_idx is None:
+            return None
+        return og.sim.scenes[self._scene_idx]
 
     def get_rule_candidates(self, rule, objects):
         """
@@ -630,11 +627,8 @@ class BaseTransitionRule(Registerable):
                 len(cls.candidate_filters) > 0
             ), "At least one of individual_filters or group_filters must be specified!"
 
-    def __init__(self, scene):
-
-        self._scene_idx = None
-        if scene is not None:
-            self._scene_idx = scene.idx
+    def __init__(self, scene_idx):
+        self._scene_idx = scene_idx
 
         self.candidates = None
         # Delay condition generation until the first time it's accessed
@@ -647,10 +641,9 @@ class BaseTransitionRule(Registerable):
             Scene or None: Scene object that this transition rule is loaded into
         """
 
-        scene = None
-        if self._scene_idx is not None:
-            scene = og.sim.scenes[self._scene_idx]
-        return scene
+        if self._scene_idx is None:
+            return None
+        return og.sim.scenes[self._scene_idx]
 
     @classproperty
     def candidate_filters(cls):

--- a/omnigibson/transition_rules.py
+++ b/omnigibson/transition_rules.py
@@ -67,7 +67,9 @@ class TransitionRuleAPI:
     """
 
     def __init__(self, scene):
-        self.scene = scene
+        self._scene_idx = None
+        if scene is not None:
+            self._scene_idx = scene.idx
 
         # Set of active rules
         self.active_rules = set()
@@ -78,6 +80,18 @@ class TransitionRuleAPI:
         self.obj_init_info = dict()
 
         self.all_rules = set([rule(scene) for rule in RULES_REGISTRY.objects])
+
+    @property
+    def scene(self):
+        """
+        Returns:
+            Scene or None: Scene object that this transition rule is loaded into
+        """
+
+        scene = None
+        if self._scene_idx is not None:
+            scene = og.sim.scenes[self._scene_idx]
+        return scene
 
     def get_rule_candidates(self, rule, objects):
         """
@@ -617,10 +631,26 @@ class BaseTransitionRule(Registerable):
             ), "At least one of individual_filters or group_filters must be specified!"
 
     def __init__(self, scene):
-        self.scene = scene
+
+        self._scene_idx = None
+        if scene is not None:
+            self._scene_idx = scene.idx
+
         self.candidates = None
         # Delay condition generation until the first time it's accessed
         self.conditions = None
+
+    @property
+    def scene(self):
+        """
+        Returns:
+            Scene or None: Scene object that this transition rule is loaded into
+        """
+
+        scene = None
+        if self._scene_idx is not None:
+            scene = og.sim.scenes[self._scene_idx]
+        return scene
 
     @classproperty
     def candidate_filters(cls):

--- a/omnigibson/utils/usd_utils.py
+++ b/omnigibson/utils/usd_utils.py
@@ -1562,12 +1562,12 @@ def get_world_prim():
     return lazy.omni.isaac.core.utils.prims.get_prim_at_path("/World")
 
 
-def scene_relative_prim_path_to_absolute(scene, relative_prim_path):
+def scene_relative_prim_path_to_absolute(scene_idx, relative_prim_path):
     """
     Converts a scene-relative prim path to an absolute prim path.
 
     Args:
-        scene (Scene or None): Scene object that the prim is in. None if it's global.
+        scene_idx (Scene index or None): Index of scene object that the prim is in. None if it's global.
         relative_prim_path (str): Relative prim path in the scene
 
     Returns:
@@ -1580,20 +1580,21 @@ def scene_relative_prim_path_to_absolute(scene, relative_prim_path):
     # Make sure the relative path is actually relative
     assert not relative_prim_path.startswith("/World"), f"Expected relative prim path, got {relative_prim_path}"
 
-    # When the scene is set to None, this prim is not in a scene but is global e.g. like the
+    # When the scene_idx is set to None, this prim is not in a scene but is global e.g. like the
     # viewer camera or one of the scene prims.
-    if scene is None:
+    if scene_idx is None:
         return "/World" + relative_prim_path
 
+    scene = og.sim.scenes[scene_idx]
     return scene.prim_path + relative_prim_path
 
 
-def absolute_prim_path_to_scene_relative(scene, absolute_prim_path):
+def absolute_prim_path_to_scene_relative(scene_idx, absolute_prim_path):
     """
     Converts an absolute prim path to a scene-relative prim path.
 
     Args:
-        scene (Scene): Scene object that the prim is in. None if it's global.
+        scene_idx (Scene index or None): Index of scene object that the prim is in. None if it's global.
         absolute_prim_path (str): Absolute prim path in the stage
 
     Returns:
@@ -1605,14 +1606,15 @@ def absolute_prim_path_to_scene_relative(scene, absolute_prim_path):
 
     assert absolute_prim_path.startswith("/World"), f"Expected absolute prim path, got {absolute_prim_path}"
 
-    # When the scene is set to None, this prim is not in a scene but is global e.g. like the
+    # When the scene_idx is set to None, this prim is not in a scene but is global e.g. like the
     # viewer camera or one of the scene prims.
-    if scene is None:
+    if scene_idx is None:
         assert not absolute_prim_path.startswith(
             "/World/scene_"
         ), f"Expected global prim path, got {absolute_prim_path}"
         return absolute_prim_path[len("/World") :]
 
+    scene = og.sim.scenes[scene_idx]
     return absolute_prim_path[len(scene.prim_path) :]
 
 


### PR DESCRIPTION
Ticket #754 
BasePrim, TransitionRuleAPI, and BaseSysten objects now store the scene index instead of the scene object. When querying a scene from these objects, it fetches the corresponding scene stored in the Simulator attributes "scenes" list.