### PR TITLE
Remove dependency on numba

### DIFF
--- a/omnigibson/simulator.py
+++ b/omnigibson/simulator.py
@@ -98,13 +98,17 @@ def _launch_app():
         import sys
         import warnings
 
-        from numba.core.errors import NumbaPerformanceWarning
+        try:
+            from numba.core.errors import NumbaPerformanceWarning
+
+            warnings.simplefilter("ignore", category=NumbaPerformanceWarning)
+        except ImportError:
+            pass
 
         # TODO: Find a more elegant way to prune omni logging
         # sys.argv.append("--/log/level=warning")
         # sys.argv.append("--/log/fileLogLevel=warning")
         # sys.argv.append("--/log/outputStreamLevel=error")
-        warnings.simplefilter("ignore", category=NumbaPerformanceWarning)
 
     # Try to import the isaacsim module that only shows up in Isaac Sim 4.0.0. This ensures that
     # if we are using the pip installed version, all the ISAAC_PATH etc. env vars are set correctly.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         "aenum~=3.1.15",
         "rtree~=1.2.0",
         "graphviz~=0.20",
-        "numba>=0.60.0",
         "matplotlib>=3.0.0",
     ],
     extras_require={},


### PR DESCRIPTION
We only use numba to try and disable its warnings. As a result we only need numba if it already exists in the env. So we remove that dependency from setup.py to avoid issues with conflicting versions in Docker, and make the import optional.