### PR TITLE
Fix missing rename behavior in old glibc versions

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -78,11 +78,11 @@ There are three ways to setup **`OmniGibson`**, all built upon different ways of
 
         3. Run the installation script to  install Isaac Sim as well as **`OmniGibson`** dataset and assets:
 
-            ```{.shell .annotate} 
-            python -m omnigibson.install # (1)!
+            ```shell
+            python -m omnigibson.install
             ```
 
-            1. You can apply additional flag `--no-install-datasets` to skip dataset install.
+            You can apply additional flag `--no-install-datasets` to skip dataset install.
 
             If this step fails, we recommend considering the [source installation](#__tabbed_1_3) method.
 
@@ -207,11 +207,11 @@ There are three ways to setup **`OmniGibson`**, all built upon different ways of
 
         4. Run the installation script to hook the environment up to Isaac Sim as well as **`OmniGibson`** dataset and assets:
 
-            ```{.shell .annotate} 
-            python -m omnigibson.install --launcher-install # (1)!
+            ```shell
+            python -m omnigibson.install --launcher-install
             ```
 
-            1. You can specify your Isaac Sim install location using the argument `--isaac-sim-path` if it differs from the default. You can also apply additional flag `--no-install-datasets` to skip dataset install.
+            You can specify your Isaac Sim install location using the argument `--isaac-sim-path` if it differs from the default. You can also apply additional flag `--no-install-datasets` to skip dataset install.
 
             !!! note "What does this do?"
 

--- a/omnigibson/install.py
+++ b/omnigibson/install.py
@@ -83,7 +83,8 @@ def _rename_if_necessary(filename: Path):
     the filename suggests not - so we apply this hacky workaround. This allows pip to try to install them.
     """
     if platform.system() == "Linux" and _is_glibc_older():
-        return filename.with_name(filename.name.replace("manylinux_2_34", "manylinux_2_31"))
+        new_filename = filename.with_name(filename.name.replace("manylinux_2_34", "manylinux_2_31"))
+        shutil.move(filename, new_filename)
     return filename
 
 

--- a/omnigibson/install.py
+++ b/omnigibson/install.py
@@ -283,7 +283,9 @@ def attempt_pip_install():
 
 @click.command()
 @click.option(
-    "--install-datasets", default=True, help="Install the OmniGibson dataset and assets after installing Isaac Sim"
+    "--install-datasets/--no-install-datasets",
+    default=True,
+    help="Install the OmniGibson dataset and assets after installing Isaac Sim",
 )
 @click.option(
     "--launcher-install/--pip-install",

--- a/omnigibson/install.py
+++ b/omnigibson/install.py
@@ -82,9 +82,13 @@ def _rename_if_necessary(filename: Path):
     This is permissible because the manylinux wheels are compatible with older GLIBC versions even though
     the filename suggests not - so we apply this hacky workaround. This allows pip to try to install them.
     """
+    # Rename the file if the system's GLIBC version is older than the one used in the NVIDIA PyPI packages
     if platform.system() == "Linux" and _is_glibc_older():
         new_filename = filename.with_name(filename.name.replace("manylinux_2_34", "manylinux_2_31"))
         shutil.move(filename, new_filename)
+        return new_filename
+
+    # If the file is not renamed, return the original filename
     return filename
 
 


### PR DESCRIPTION
Also fix small issue in dataset install parameter name.

Also unfold the dataset install and isaac path parameters from the + button into just always-visible text.